### PR TITLE
syncer: Remove new sync partner status, even if no other data is syncd

### DIFF
--- a/syncer.c
+++ b/syncer.c
@@ -411,11 +411,6 @@ resync ()
                     apteryx_set_tree (data);
                 }
             }
-            else
-            {
-                /* These ones will have got all the data above */
-                sp->new_joiner = false;
-            }
         }
     }
 
@@ -423,6 +418,13 @@ resync ()
     {
         apteryx_free_tree (data);
         data = NULL;
+    }
+
+    for (iter = partners; iter; iter = iter->next)
+    {
+        /* All partners are now up to date */
+        sync_partner *sp = iter->data;
+        sp->new_joiner = false;
     }
 
     last_sync_local = local_ts;


### PR DESCRIPTION
If a sync partner is new, and there are no changes since the last
resync, it would have stayed new forever.

Now always set the sync partners to old whenever resync is called.