### PR TITLE
Make syncer exclude paths represent start of path to be excluded.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ install: all
 	@install -D apteryx-sync $(DESTDIR)/$(PREFIX)/bin/
 	@install -D alfred $(DESTDIR)/$(PREFIX)/bin/
 	@install -D saver $(DESTDIR)/$(PREFIX)/bin/
+	@install -d $(DESTDIR)/$(PREFIX)/include
+	@install -D apteryx_sync.h $(DESTDIR)/$(PREFIX)/include/
 
 clean:
 	@echo "Cleaning..."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+Utility applications to be used with the Apteryx Centralized configuration database.
+
+## ALFRED
+**A**pteryx **L**ightweight **F**eatu**re** **D**aemon
+
+Generic daemon that implements Apteryx Watch, Provide and Index actions.
+
+This allows apteryx_sets to a particular Apteryx XML node to be actioned and state/status information to be provided when apteryx_get is called
+
+Definition of the feature API and implementation in a single XML file. Actions to be taken or responses to be given are defined as inline or imported lua scripts.
+
+* Actions  are specified in the tree structure using the tags `<WATCH>`, `<PROVIDE>` and `<INDEX>`.
+* Additional Lua functions are provided using the `<SCRIPT>` tag.
+* Actions are implemented using Lua scripting.
+* All XML files in /etc/apteryx/schema are parsed at daemon startup.
+
+Use alfred -h for options:
+```
+# alfred -h
+Usage: alfred [-h] [-b] [-d] [-p <pidfile>] [-c <configdir>] [-u <filter>]
+  -h   show this help
+  -b   background mode
+  -d   enable verbose debug
+  -m   memory profiling
+  -p   use <pidfile> (defaults to /var/run/apteryx-alfred.pid)
+  -c   use <configdir> (defaults to /etc/apteryx/schema/)
+  -u   Run unit tests
+```
+
+Simple example:
+```
+<MODULE xmlns="https://github.com/alliedtelesis/apteryx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/alliedtelesis/apteryx https://github.com/alliedtelesis/apteryx/releases/download/v2.04/apteryx.xsd">
+    <SCRIPT>
+        function system_get_meminfo(type)
+            local f = io.popen("cat /proc/meminfo | grep "..type.." | awk '{print $2}'", 'r')
+            local value = f:read()
+            f:close()
+            return value
+        end
+        function system_ram_total(ram)
+            return system_get_meminfo('MemTotal')
+        end
+        function system_ram_free(ram)
+            return system_get_meminfo('MemFree')
+        end
+    </SCRIPT>
+    <NODE name="system">
+        <NODE name="reboot" mode="w" help="Command to halt and perform a cold restart" pattern="^1$">
+            <VALUE name="now" value="1" help="The device is told to halt and perform a cold restart"/>
+            <WATCH>
+                os.execute("/sbin/pre_shutdown")
+                os.execute("fastboot \"Rebooting at user request\"")
+            </WATCH>
+        </NODE>
+        <NODE name="ram" help="Ram memory information">
+            <NODE name="total" mode="r" help="Total RAM (kB)">
+                <PROVIDE>return system_ram_total()</PROVIDE>
+            </NODE>
+            <NODE name="free" mode="r" help="Total free RAM (kB)">
+                <PROVIDE>return system_ram_free()</PROVIDE>
+            </NODE>
+        </NODE>
+    </NODE>
+</MODULE>
+```
+
+Depends on apteryx-xml
+
+## Saver
+Utility daemon to save Apteryx database contents to persistent storage. Uses Apteryx XML schema
+files to determine which database entries should be saved. Only entries marked with mode 'c' (config)
+are saved.
+
+The entries stored in persistent storage can be loaded into the database when saver starts up, using
+the -l option.
+
+Use saver -h for options:
+```
+# saver -h
+Usage: saver [-h] [-b] [-d] [-p <pidfile>] [-c <configdir>] [-u <filter>] [-w <writedelay>]
+  -h   show this help
+  -b   background mode
+  -d   enable verbose debug
+  -p   use <pidfile> (defaults to /var/run/saver.pid)
+  -c   use <configdir> to search for schemas (defaults to /etc/apteryx/schema/)
+  -f   use <configfile> for saving configuration (defaults to /etc/apteryx/saver.cfg)
+  -w   set write delay (defaults to 15 seconds)
+  -l   load in configuration at startup
+  -u   Run unit tests
+```
+
+Depends on apteryx-xml
+
+## Syncer
+Syncs selected data from the local Apteryx database to other remote Apteryx databases
+
+Use apteryx-sync -h for options:
+
+```
+# apteryx-sync -h
+Usage: apteryx-sync [-h] [-b] [-d] [-p <pidfile>] [-c <configdir>]
+  -h   show this help
+  -b   background mode
+  -d   enable verbose debug
+  -p   use <pidfile> (defaults to /var/run/apteryx-sync.pid)
+  -c   use <configdir> (defaults to /etc/apteryx/sync/)
+```
+
+To register a remote Apteryx to sync to, add it to Apteryx at /apteryx-sync/destinations
+before or after starting apteryx-sync. e.g.
+
+```
+apteryx -s /apteryx-sync/destinations/remote-1 tcp://192.168.1.2:9999
+```
+
+In c, this can be done by including apteryx_sync.h and using the following apteryx call:
+```
+apteryx_set_string (APTERYX_SYNC_DESTINATIONS_PATH, dest_name, dest_url);
+apteryx_set_string (APTERYX_SYNC_DESTINATIONS_PATH, "remote-1", "tcp://192.168.1.2:9999");
+```
+
+Paths to sync are stored in config files in a configurable directory (/etc/apteryx/sync/ by default).
+All files in this directory are read in.
+
+* To sync a particular path and all sub-paths, add the path on a new line with a trailing /*. e.g.
+```
+/path/to/sync/*
+```
+* To exclude a particular node in a synced path, add it as a new line preceded by an '!'. e.g.
+```
+!/path/to/sync/excluded_node
+```
+* To exclude all paths that begin with a certain string, end the exclude path with a '*'. e.g.
+```
+!/path/to/sync/exclude_tree*
+```
+* Lines starting with a # are treated as comments

--- a/apteryx_sync.h
+++ b/apteryx_sync.h
@@ -1,0 +1,36 @@
+/**
+ * @file apteryx_sync.h
+ *
+ * Header file for Apteryx syncer utility
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>
+ */
+#ifndef _APTERYX_SYNC_H_
+#define _APTERYX_SYNC_H_
+#include <apteryx.h>
+
+/* Apteryx sync path was previously defined in apteryx.h, so protect old Apteryx version.
+ * apteryx.h included above to ensure that there can't be a mismatch. */
+#ifndef APTERYX_SYNC_PATH
+#define APTERYX_SYNC_PATH "/apteryx-sync"
+#endif /* !APTERYX_SYNC_PATH */
+
+#define APTERYX_SYNC_DESTINATIONS_PATH APTERYX_SYNC_PATH "/destinations"
+/* To Add/update a destination for the Apteryx syncer use the following:
+ * apteryx_set_string (APTERYX_SYNC_DESTINATIONS_PATH, dest_name, dest_url);
+ *
+ * Use NULL dest_url to remove destination
+ */
+
+#endif /* _APTERYX_SYNC_H_ */

--- a/syncer.c
+++ b/syncer.c
@@ -7,6 +7,7 @@
 #include <apteryx.h>
 #include <glib-unix.h>
 #include "common.h"
+#include "apteryx_sync.h"
 
 #define APTERYX_SYNC_PID "/var/run/apteryx-sync.pid"
 #define APTERYX_SYNC_CONFIG_DIR "/etc/apteryx/sync/"
@@ -476,26 +477,20 @@ register_existing_partners (void)
 {
     GList *iter = NULL;
     char *value = NULL;
-    char *path = NULL;
-    /* get all paths under the APTERYX_SYNC_PATH node
+
+    /* get all paths under the APTERYX_SYNC_DESTINATIONS_PATH node
      * note: need to add a "/" on the end for search to work
      */
-    GList *existing_partners = apteryx_search (APTERYX_SYNC_PATH "/");
+    GList *existing_partners = apteryx_search (APTERYX_SYNC_DESTINATIONS_PATH "/");
     /* for each path in the search result, get the value and create a new syncer */
     iter = existing_partners;
     while (iter != NULL)
     {
         DEBUG ("Adding existing partner %s\n", (char *) iter->data);
-        /* the path is a char* in the iter->data. need to add "/*" to the end */
-        if (asprintf (&path, "%s/*", (char *) iter->data) <= 0)
-        {
-            /* shouldn't fail, but if it does we can't do any more with it */
-            continue;
-        }
-        value = apteryx_get (path);
-        new_syncer (path, value);
+        value = apteryx_get (iter->data);
+        new_syncer (iter->data, value);
         free (value);
-        free (path);
+
         /* finished with this entry. move along, nothing to see here. */
         iter = iter->next;
     }
@@ -703,7 +698,7 @@ main (int argc, char *argv[])
     }
 
     /* The sync path is how applications can register the nodes to sync to */
-    apteryx_watch (APTERYX_SYNC_PATH "/*", new_syncer);
+    apteryx_watch (APTERYX_SYNC_DESTINATIONS_PATH "/*", new_syncer);
 
     /* next, we need to check for any existing nodes and setup syncers for them */
     register_existing_partners ();

--- a/syncer.c
+++ b/syncer.c
@@ -224,9 +224,27 @@ bool
 sync_path_excluded (const char *path)
 {
     pthread_rwlock_rdlock (&paths_lock);
+    int len;
+    char *exclude_path;
+    int ret;
+
     for (GList *iter = excluded_paths; iter; iter = iter->next)
     {
-        if (strcmp (path, iter->data) == 0)
+        exclude_path = (char *) iter->data;
+        len = strlen (exclude_path);
+
+        if (len && exclude_path[len - 1] == '*')
+        {
+            /* Match all paths beginning with this string */
+            ret = strncmp (path, exclude_path, len - 1);
+        }
+        else
+        {
+            /* Match exact path */
+            ret = strcmp (path, exclude_path);
+        }
+
+        if (ret == 0)
         {
             pthread_rwlock_unlock (&paths_lock);
             return true;


### PR DESCRIPTION
Currently there is no way to exclude an entire subtree.  By using strncmp
rather than strcmp for exclude paths, we can use exclude to exclude
everything that begins with a certain path.

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>