### PR TITLE
Add support to after_quiet() and rate_limit() to accept a function

### DIFF
--- a/alfred.c
+++ b/alfred.c
@@ -89,6 +89,40 @@ alfred_error (lua_State *ls, int res)
 }
 
 static bool
+alfred_call (lua_State *ls, int nresults)
+{
+    int res, s_0 = lua_gettop (ls);
+    size_t fargs = lua_rawlen(ls, -1) - 1;
+
+    /* Load stack with function and its arguments from table */
+    for (size_t i = 1; i <= fargs + 1; i++)
+    {
+        lua_rawgeti(ls, s_0, i);
+    }
+
+    res = lua_pcall (ls, (int)(fargs), nresults, 0);
+    if (res != 0)
+        alfred_error (ls, res);
+
+    if (lua_gettop (ls) != (s_0 + nresults))
+    {
+        lua_Debug ar;
+
+        /* Push function back on the stack to get some details */
+        lua_rawgeti(ls, s_0, 1);
+        lua_getinfo(ls, ">nS", &ar);
+        printf ("Lua: Stack not zero(%d) after function: %s:%d:%s\n",
+                lua_gettop (ls),
+                ar.source && ar.source[0] != '\0' ? ar.source : "(unknown)",
+                ar.linedefined,
+                ar.name && ar.name[0] != '\0' ? ar.name : "(unknown)");
+        lua_pop(ls, 1);
+    }
+
+    return (res == 0);
+}
+
+static bool
 alfred_exec (lua_State *ls, const char *script, int nresults)
 {
     int res = 0;
@@ -646,6 +680,7 @@ load_config_files (alfred_instance alfred, const char *path)
 GList *delayed_work = NULL;
 struct delayed_work_s {
     guint id;
+    int call;
     char *script;
 };
 
@@ -653,6 +688,8 @@ static void
 dw_destroy (gpointer arg1)
 {
     struct delayed_work_s *dw = (struct delayed_work_s *) arg1;
+    luaL_unref (alfred_inst->ls, LUA_REGISTRYINDEX, dw->call);
+    dw->call = LUA_NOREF;
     g_free (dw->script);
     g_free (dw);
 }
@@ -665,98 +702,150 @@ delayed_work_process (gpointer arg1)
     /* Remove the script to be run */
     delayed_work = g_list_remove (delayed_work, dw);
 
-    /* Execute the script */
-    alfred_exec (alfred_inst->ls, dw->script, 0);
+    if (dw->script)
+    {
+        /* Execute the script */
+        alfred_exec (alfred_inst->ls, dw->script, 0);
+    }
+    else
+    {
+        lua_rawgeti (alfred_inst->ls, LUA_REGISTRYINDEX, dw->call);
+        alfred_call (alfred_inst->ls, 0);
+        lua_pop (alfred_inst->ls, 0);
+    }
+
     return false;
 }
 
 static void
-delayed_work_add (int delay, const char *script, bool reset_timer)
+delayed_work_add (lua_State *ls, bool reset_timer)
 {
+    int call_args = 0;
     bool found = false;
+    const char *script = NULL;
     struct delayed_work_s *dw = NULL;
 
-    for (GList * iter = delayed_work; iter; iter = g_list_next (iter))
+    if (lua_isstring (ls, 2))
+    {
+        script = lua_tostring(ls, 2);
+    }
+    else /* lua_isfunction(ls, 2) */
+    {
+        call_args = lua_gettop (ls) - 1;
+    }
+
+    for (GList * iter = delayed_work; iter && !found; iter = g_list_next (iter))
     {
         dw = (struct delayed_work_s *) iter->data;
-        if (strcmp (script, dw->script) == 0)
+        if (script)
         {
-            found = true;
-            if (reset_timer)
+            found = dw->script && strcmp (script, dw->script) == 0;
+        }
+        else if (lua_isfunction (ls, 2)
+                 && dw->call != LUA_NOREF && dw->call != LUA_REFNIL)
+        {
+            size_t len;
+            bool call_same = true;
+
+            lua_rawgeti(ls, LUA_REGISTRYINDEX, dw->call);
+            /* Try to avoid comparing calls */
+            len = lua_rawlen(ls, -1);
+            if (((size_t)call_args) != len)
             {
-                delayed_work = g_list_remove (delayed_work, dw);
-                g_source_remove (dw->id);
+                lua_pop(ls, 1);
+                continue;
             }
-            break;
+            for (size_t i = 0; call_same && i < call_args; i++)
+            {
+                lua_rawgeti(ls, -1, i + 1);
+                /* lua_compare has the usual meaning in lua, tables with
+                 * the same keys and values will not be counted as the same,
+                 * unless metamethods are changed.
+                 */
+                call_same = lua_compare(ls, i + 2, -1, LUA_OPEQ);
+                lua_pop(ls, 1);
+            }
+            found = call_same;
+            lua_pop(ls, 1);
+        }
+        if (found && reset_timer)
+        {
+            delayed_work = g_list_remove (delayed_work, dw);
+            g_source_remove (dw->id);
         }
     }
+
     if (!found || reset_timer)
     {
-        dw = (struct delayed_work_s *) g_malloc0 (sizeof (struct delayed_work_s));
-        dw->script = g_strdup (script);
+        struct delayed_work_s *dw = (struct delayed_work_s *) g_malloc0 (sizeof (struct delayed_work_s));
+
+        if (script)
+        {
+            dw->script = g_strdup (script);
+        }
+        else
+        {
+            /* Transfer stack (past delay) into the argument table */
+            lua_newtable(ls);
+            lua_pushvalue(ls, 2);
+            lua_rawseti(ls, -2, 1);
+            lua_replace(ls, 2);
+            for (int i = lua_gettop (ls); i > 2; i--)
+            {
+                lua_rawseti(ls, 2, i - 1);
+            }
+            dw->call = luaL_ref(ls, LUA_REGISTRYINDEX);
+        }
         delayed_work = g_list_append (delayed_work, dw);
-        dw->id = g_timeout_add_full (G_PRIORITY_DEFAULT, delay, delayed_work_process,
-                                     (gpointer) dw, dw_destroy);
+        dw->id = g_timeout_add_full (G_PRIORITY_DEFAULT,
+                                     lua_tonumber (ls, 1) * SECONDS_TO_MILLI,
+                                     delayed_work_process, (gpointer) dw, dw_destroy);
     }
+}
+
+static int
+validate_script_or_function_args (lua_State *ls, const char *funct)
+{
+    bool success = true;
+
+    if (!lua_isnumber (ls, 1))
+    {
+        ERROR ("First argument to %s must be a number\n", funct);
+        success = false;
+    }
+    if (lua_isstring (ls, 2))
+    {
+        if (lua_gettop (ls) != 2)
+        {
+            ERROR ("%s takes 2 arguements\n", funct);
+            success = false;
+        }
+    }
+    else if (!lua_isfunction (ls, 2))
+    {
+        ERROR ("Second argument to %s must be a string or Lua function\n", funct);
+        success = false;
+    }
+    return success;
 }
 
 static int
 rate_limit (lua_State *ls)
 {
-    bool failure = false;
-    if (lua_gettop (ls) != 2)
+    if (validate_script_or_function_args (ls, "Alfred.rate_limit()"))
     {
-        ERROR ("Alfred.rate_limit() takes 2 arguements\n");
-        failure = true;
+        delayed_work_add (ls, false);
     }
-    if (!lua_isnumber (ls, 1))
-    {
-        ERROR ("First argument to Alfred.rate_limit() must be a number\n");
-        failure = true;
-    }
-    if (!lua_isstring (ls, 2))
-    {
-        ERROR ("Second argument to Alfred.rate_limit() must be a string\n");
-        failure = true;
-    }
-
-    if (failure)
-    {
-        return 0;
-    }
-
-    delayed_work_add (lua_tonumber (ls, 1) * SECONDS_TO_MILLI, lua_tostring (ls, 2), false);
-
     return 0;
 }
 
 static int
 after_quiet (lua_State *ls)
 {
-    bool failure = false;
-    if (lua_gettop (ls) != 2)
+    if (validate_script_or_function_args (ls, "Alfred.after_quiet()"))
     {
-        ERROR ("Alfred.after_quiet() takes 2 arguements\n");
-        failure = true;
+        delayed_work_add (ls, true);
     }
-    if (!lua_isnumber (ls, 1))
-    {
-        ERROR ("First argument to Alfred.after_quiet() must be a number\n");
-        failure = true;
-    }
-    if (!lua_isstring (ls, 2))
-    {
-        ERROR ("Second argument to Alfred.after_quiet() must be a string\n");
-        failure = true;
-    }
-
-    if (failure)
-    {
-        return 0;
-    }
-
-    delayed_work_add (lua_tonumber (ls, 1) * SECONDS_TO_MILLI, lua_tostring (ls, 2), true);
-
     return 0;
 }
 

--- a/alfred.c
+++ b/alfred.c
@@ -1568,6 +1568,7 @@ test_rate_limit ()
     FILE *library = NULL;
     FILE *data = NULL;
     char *test_str = NULL;
+    lua_Integer test_count;
 
     apteryx_init (false);
     /* Create library file + XML */
@@ -1576,8 +1577,10 @@ test_rate_limit ()
     if (library)
     {
         fprintf (library,
+            "count = 0\n\n"
             "function test_library_function(test_str)\n"
             "  test_value = test_str\n"
+            "  count = count + 1\n"
             "end\n"
             );
         fclose (library);
@@ -1629,7 +1632,12 @@ test_rate_limit ()
         }
         lua_pop (alfred_inst->ls, 1);
 
+        lua_getglobal (alfred_inst->ls, "count");
+        test_count = lua_tointeger(alfred_inst->ls, -1);
+        lua_pop (alfred_inst->ls, 1);
+
         g_assert (test_str && strcmp (test_str, "Goodnight scoot") == 0);
+        g_assert (test_count < 50);
         apteryx_set ("/test/set_node", NULL);
         sleep(1);
     }
@@ -1651,6 +1659,7 @@ test_after_quiet ()
     FILE *library = NULL;
     FILE *data = NULL;
     char *test_str = NULL;
+    lua_Integer test_count;
 
     apteryx_init (false);
     /* Create library file + XML */
@@ -1659,8 +1668,10 @@ test_after_quiet ()
     if (library)
     {
         fprintf (library,
+                "count = 0\n\n"
                 "function test_library_function(test_str)\n"
                 "  test_value = test_str\n"
+                "  count = count + 1\n"
                 "end\n"
                 );
         fclose (library);
@@ -1712,7 +1723,12 @@ test_after_quiet ()
         }
         lua_pop (alfred_inst->ls, 1);
 
+        lua_getglobal (alfred_inst->ls, "count");
+        test_count = lua_tointeger(alfred_inst->ls, -1);
+        lua_pop (alfred_inst->ls, 1);
+
         g_assert (test_str && strcmp (test_str, "Goodnight scoot") == 0);
+        g_assert (test_count == 1);
         apteryx_set ("/test/set_node", NULL);
         sleep(1);
     }

--- a/alfred.c
+++ b/alfred.c
@@ -1658,8 +1658,6 @@ test_after_quiet ()
 {
     FILE *library = NULL;
     FILE *data = NULL;
-    char *test_str = NULL;
-    lua_Integer test_count;
 
     apteryx_init (false);
     /* Create library file + XML */
@@ -1668,12 +1666,18 @@ test_after_quiet ()
     if (library)
     {
         fprintf (library,
-                "count = 0\n\n"
-                "function test_library_function(test_str)\n"
-                "  test_value = test_str\n"
-                "  count = count + 1\n"
-                "end\n"
-                );
+                 "count = 0\n\n"
+                 "function test_library_function(test_str)\n"
+                 "  test_value = test_str\n"
+                 "  count = count + 1\n"
+                 "end\n\n"
+                 "function test_library_function2(...)\n"
+                 "  local args = table.pack(...)\n"
+                 "  test_value = \"CONCATED:\"\n"
+                 "  for i=1, args.n do\n"
+                 "    test_value = test_value .. tostring(args[i])\n"
+                 "  end\n"
+                 "end\n");
         fclose (library);
     }
 
@@ -1692,8 +1696,17 @@ test_after_quiet ()
                     "  end\n"
                     "  </SCRIPT>\n"
                     "  <NODE name=\"test\">\n"
-                    "    <NODE name=\"set_node\" mode=\"rw\"  help=\"Set this node to test the watch function\">\n"
-                    "      <WATCH>Alfred.after_quiet(0.1,'test_node_change(_value)')</WATCH>\n"
+                    "    <NODE name=\"set_script_node\" mode=\"rw\">\n"
+                    "      <WATCH>Alfred.after_quiet(0.1, 'test_node_change(_value)')</WATCH>\n"
+                    "    </NODE>\n"
+                    "    <NODE name=\"set_function_node\" mode=\"rw\">\n"
+                    "      <WATCH>Alfred.after_quiet(0.1, test_library_function2)</WATCH>\n"
+                    "    </NODE>\n"
+                    "    <NODE name=\"set_function_arg_node\" mode=\"rw\">\n"
+                    "      <WATCH>Alfred.after_quiet(0.1, test_library_function, _value)</WATCH>\n"
+                    "    </NODE>\n"
+                    "    <NODE name=\"set_function_many_args_node\" mode=\"rw\">\n"
+                    "      <WATCH>Alfred.after_quiet(0.1, test_library_function2, nil, 1, '\\\\2', 3, false, _value, true, nil, 4, '5', 6)</WATCH>\n"
                     "    </NODE>\n"
                     "  </NODE>\n"
                     "</MODULE>\n");
@@ -1705,32 +1718,58 @@ test_after_quiet ()
     g_assert (alfred_inst != NULL);
     if (alfred_inst)
     {
-        /* Trigger Action */
-        int count = 0;
+        char *test_str = NULL;
+        lua_Integer test_count;
+        struct {
+            const char *node;
+            const char *check;
+        } tests[4];
 
-        while (count < 50)
+        tests[0].node = "/test/set_script_node";
+        tests[0].check = "Goodnight scoot";
+        tests[1].node = "/test/set_function_node";
+        tests[1].check = "CONCATED:";
+        tests[2].node = "/test/set_function_arg_node";
+        tests[2].check = "Goodnight scoot";
+        tests[3].node = "/test/set_function_many_args_node";
+        tests[3].check = "CONCATED:nil1\\23falseGoodnight scoottruenil456";
+
+        for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++)
         {
-            apteryx_set ("/test/set_node", "Goodnight scoot");
-            count++;
+            int count = 0;
+
+            while (count < 50)
+            {
+                apteryx_set (tests[i].node, "Goodnight scoot");
+                count++;
+            }
+
+            sleep (1);
+            /* Check output */
+            lua_getglobal (alfred_inst->ls, "test_value");
+            if (!lua_isnil (alfred_inst->ls, -1))
+            {
+                test_str = strdup (lua_tostring (alfred_inst->ls, -1));
+            }
+            lua_pop (alfred_inst->ls, 1);
+
+            lua_getglobal (alfred_inst->ls, "count");
+            test_count = lua_tointeger(alfred_inst->ls, -1);
+            lua_pop (alfred_inst->ls, 1);
+
+            g_assert (test_str && strcmp (test_str, tests[i].check) == 0);
+            g_assert (test_count == 1);
+
+            /* Reset Lua variables */
+            lua_pushnil(alfred_inst->ls);
+            lua_setglobal(alfred_inst->ls, "test_value");
+            lua_pushinteger (alfred_inst->ls, (lua_Integer)0);
+            lua_setglobal(alfred_inst->ls, "count");
+
+            apteryx_set (tests[i].node, NULL);
+            free (test_str);
+            sleep(1);
         }
-
-        sleep (1);
-        /* Check output */
-        lua_getglobal (alfred_inst->ls, "test_value");
-        if (!lua_isnil (alfred_inst->ls, -1))
-        {
-            test_str = strdup (lua_tostring (alfred_inst->ls, -1));
-        }
-        lua_pop (alfred_inst->ls, 1);
-
-        lua_getglobal (alfred_inst->ls, "count");
-        test_count = lua_tointeger(alfred_inst->ls, -1);
-        lua_pop (alfred_inst->ls, 1);
-
-        g_assert (test_str && strcmp (test_str, "Goodnight scoot") == 0);
-        g_assert (test_count == 1);
-        apteryx_set ("/test/set_node", NULL);
-        sleep(1);
     }
 
     /* Clean up */
@@ -1740,7 +1779,6 @@ test_after_quiet ()
     }
     unlink ("alfred_test.lua");
     unlink ("alfred_test.xml");
-    free (test_str);
 }
 
 static gboolean


### PR DESCRIPTION
Simplify the usage of after_quiet() and rate_limit() with user input by accepting a function, followed by its arguments. This avoids the arguments needing to be parsed by the Lua interpreter.