### PR TITLE
Support root node namespace mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ apteryxd = \
 test: alfred
 	@echo "Running unit test: $<"
 	$(Q)$(call apteryxd,alfred -u)
-	$(Q)rm -f alfred_test.xml alfred_test.lua
+	$(Q)rm -f alfred_test.xml alfred_test.map alfred_test.lua
 	@echo "Tests have been run!"
 
 install: all


### PR DESCRIPTION
This allows us to have duplicate root nodes in data models but unique DB root nodes.