### PR TITLE
apteryx-saver: Check for apteryx_query() failure whilst writing config

### DIFF
--- a/saver.c
+++ b/saver.c
@@ -279,7 +279,14 @@ write_config_process (gpointer arg1)
             apteryx_free_tree (config_nodes);
         config_nodes = apteryx_query (saver_nodes);
     }
-    _write_config ();
+    if (config_nodes)
+    {
+        _write_config ();
+    }
+    else
+    {
+        ERROR("Failed to fetch config to write");
+    }
     pthread_mutex_unlock (&config_lock);
     return G_SOURCE_CONTINUE;
 }


### PR DESCRIPTION
Check for apteryx_query() failure whilst writing config. Apteryx_query() can return NULL if a refresher path included in the query doesn't respond to apteryxd.

I saw this issue due to Alfred not responding to refreshers whilst processing a watch callback.