### PR TITLE
Add support for syncing more complex paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ All files in this directory are read in.
 ```
 /path/to/sync/*
 ```
+* Any path that will work with the CLI "apterxy -q path" can be used. e.g.
+```
+/path/to/sync/*/specific/information
+```
 * To exclude a particular node in a synced path, add it as a new line preceded by an '!'. e.g.
 ```
 !/path/to/sync/excluded_node


### PR DESCRIPTION
It is currently difficult to sync on a small portion of a model if that model includes a list element. For example /node1/node2/*/node3/node4. The current method would be to select node1/node2/* then exclude the unwanted fields. This however can cause substantial processing.

This change allows paths of type /node1/node2/*/node3/node4 to be entered. The new code uses apteryx_query and apteryx_watch_tree to retrieve the database information to synchronize.

Additionally exclude paths are now only applied to the model they were added with.