### PR TITLE
Build apteryx-sync tree as a proper tree

### DIFF
--- a/syncer.c
+++ b/syncer.c
@@ -338,7 +338,7 @@ sync_tree_process (GNode *node, gpointer arg)
             ts = apteryx_timestamp (path);
             if (ts && ts > params->ts)
             {
-                APTERYX_LEAF (params->root, strdup (path + 1), (char *) node->data);
+                apteryx_path_to_node (params->root, path, node->data);
                 node->data = NULL;
             }
         }


### PR DESCRIPTION
The previous code was putting full paths in just below the root node. This hampers performance, so build the tree properly.