### PR TITLE
Avoid deprecated libxml2 function

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Run apteryxd
       run: LD_LIBRARY_PATH=./apteryx ./apteryx/apteryxd -b
     - name: Run Alfred unit tests
-      run: LD_LIBRARY_PATH=./apteryx:./apteryx-xml:. G_SLICE=always-malloc valgrind --keep-debuginfo=yes --leak-check=full --error-exitcode=1 ./alfred -u
+      run: LD_LIBRARY_PATH=./apteryx:./apteryx-xml:. G_SLICE=always-malloc valgrind --keep-debuginfo=yes --leak-check=full --error-exitcode=1 --suppressions=./apteryx.suppressions ./alfred -u

--- a/alfred.c
+++ b/alfred.c
@@ -714,7 +714,11 @@ load_config_files (alfred_instance alfred, const char *path)
 
             DEBUG ("ALFRED: Parse XML file \"%s\" into instance \"xml-default\"\n", filename);
             /* Parse the file */
+#if LIBXML_VERSION >= 21400
+            xmlDoc *doc = xmlReadFile (filename, NULL, XML_PARSE_UNZIP);
+#else   /* LibXML < 2.14.0 */
             xmlDoc *doc = xmlParseFile (filename);
+#endif  /* LIBXML_VERSION */
             if (doc == NULL)
             {
                 CRITICAL ("ALFRED: Invalid file \"%s\"\n", filename);

--- a/apteryx.suppressions
+++ b/apteryx.suppressions
@@ -1,0 +1,18 @@
+{
+   ignore_apteryx_callback_subthread
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.34
+   obj:/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8000.0
+   fun:g_thread_new
+   fun:g_thread_pool_new_full
+   fun:request_cb
+   fun:listen_thread
+   fun:start_thread
+   fun:clone
+}


### PR DESCRIPTION
In LibXML 2.14.0, xmlParseFile was deprecated in favour of xmlReadFile. The new function allows specification of parser options as defined by the xmlParserOption struct:
https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/include/libxml/parser.h#L1678

XML_PARSE_UNZIP is currently enabled by default in xmlReadFile but may be subject to change. Parsing Gzip-compressed files is no longer supported by xmlParseFile.

Support maintained with earlier versions of LibXML2 for unit testing.