### PR TITLE
Add recorder for tracking apteryx changes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -33,3 +33,5 @@ jobs:
       run: LD_LIBRARY_PATH=./apteryx ./apteryx/apteryxd -b
     - name: Run Alfred unit tests
       run: LD_LIBRARY_PATH=./apteryx:./apteryx-xml:. G_SLICE=always-malloc valgrind --keep-debuginfo=yes --leak-check=full --error-exitcode=1 --suppressions=./apteryx.suppressions ./alfred -u
+    - name: Run recorder unit tests
+      run: LD_LIBRARY_PATH=./apteryx:. G_SLICE=always-malloc valgrind --keep-debuginfo=yes --leak-check=full --error-exitcode=1 --suppressions=./apteryx.suppressions ./recorder -u

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ EXTRA_CFLAGS += -DHAVE_LIBXML2 $(shell $(PKG_CONFIG) --cflags libxml-2.0)
 EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs libxml-2.0)
 EXTRA_CFLAGS += -DHAVE_LIBJANSSON $(shell $(PKG_CONFIG) --cflags jansson)
 EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs jansson)
+EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs cunit)
 
 all: alfred apteryx-sync apteryx-saver recorder
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Makefile for Apteryx
 #
 # Unit Tests (make test FILTER): e.g make test Alfred
-# Requires GLib, Lua and libXML2.
-# sudo apt-get install libglib2.0-dev liblua5.2-dev libxml2-dev libcunit1-dev
+# Requires GLib, Lua, Jansson and libXML2.
+# sudo apt-get install libglib2.0-dev liblua5.2-dev libxml2-dev libcunit1-dev libjansson-dev
 #
 # TEST_WRAPPER="G_SLICE=always-malloc valgrind --leak-check=full" make test
 # TEST_WRAPPER="gdb --args" make test
@@ -17,8 +17,8 @@ PREFIX?=/usr/
 CC:=$(CROSS_COMPILE)gcc
 LD:=$(CROSS_COMPILE)ld
 PKG_CONFIG ?= pkg-config
-APTERYX_PATH ?=
-APTERYX_XML_PATH ?=
+APTERYX_PATH ?= "../apteryx"
+APTERYX_XML_PATH ?= "../apteryx-xml"
 
 CFLAGS := $(CFLAGS) -g -O2
 EXTRA_CFLAGS += -Wall -Wno-comment -std=c99 -D_GNU_SOURCE -fPIC
@@ -43,12 +43,18 @@ EXTRA_CFLAGS += -DHAVE_LUA $(shell $(PKG_CONFIG) --cflags $(LUAVERSION))
 EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs $(LUAVERSION)) -ldl
 EXTRA_CFLAGS += -DHAVE_LIBXML2 $(shell $(PKG_CONFIG) --cflags libxml-2.0)
 EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs libxml-2.0)
+EXTRA_CFLAGS += -DHAVE_LIBJANSSON $(shell $(PKG_CONFIG) --cflags jansson)
+EXTRA_LDFLAGS += $(shell $(PKG_CONFIG) --libs jansson)
 
-all: alfred apteryx-sync apteryx-saver
+all: alfred apteryx-sync apteryx-saver recorder
 
 %.o: %.c
 	@echo "Compiling "$<""
 	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c $< -o $@
+
+recorder: recorder.o
+	@echo "Building $@"
+	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^ $(EXTRA_LDFLAGS)
 
 apteryx-saver: saver.o
 	@echo "Building $@"
@@ -72,6 +78,8 @@ apteryxd = \
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):./:$(APTERYX_PATH):$(APTERYX_XML_PATH) $(TEST_WRAPPER) ./$(1); \
 	kill -TERM `cat /tmp/apteryxd.pid`;
 
+
+# Nothing added for recorder yet....
 test: alfred apteryx-saver
 	@echo "Running unit test: alfred"
 	$(Q)$(call apteryxd,alfred -u)
@@ -83,6 +91,7 @@ test: alfred apteryx-saver
 
 install: all
 	@install -d $(DESTDIR)/$(PREFIX)/bin
+	@install -D recorder $(DESTDIR)/$(PREFIX)/bin/
 	@install -D apteryx-sync $(DESTDIR)/$(PREFIX)/bin/
 	@install -D alfred $(DESTDIR)/$(PREFIX)/bin/
 	@install -D apteryx-saver $(DESTDIR)/$(PREFIX)/bin/
@@ -91,6 +100,6 @@ install: all
 
 clean:
 	@echo "Cleaning..."
-	$(Q)rm -f apteryx-sync alfred saver *.o
+	$(Q)rm -f apteryx-sync alfred saver recorder *.o
 
 .PHONY: all clean

--- a/recorder.c
+++ b/recorder.c
@@ -1,22 +1,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <ctype.h>
-#include <pthread.h>
-#include <dirent.h>
 #include <apteryx.h>
 #include <glib-unix.h>
-#include <apteryx-xml.h>
-#include <syslog.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <errno.h>
 #include <time.h>
+#include <getopt.h>
+#include <dirent.h>
 #include <libgen.h>
 #include <jansson.h>
-#include "common.h"
-#include "apteryx_sync.h"
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
 
 static const int path_buffer = 256;
 static const int json_indent = 2;
@@ -328,36 +324,21 @@ thread_func (gpointer user_data)
 
 
 static int
-validate_destination (json_t *destination, char **destination_array, size_t *dest_count)
+validate_destination (json_t *destination)
 {
     char *dest_str = strdup (json_string_value (destination));
 
     if (make_path (dest_str) != 0)
     {
-        fprintf (stderr, "error: failed to create specified path: %s\n", dest_str);
+        fprintf (stderr, "error: failed to create specified destination path: %s\n", dest_str);
         return -1;
     }
 
-    char *abs_path = resolve_absolute_path (dest_str);
-
-    for (size_t i = 0; i < *dest_count; i++)
-    {
-        if (strcmp (destination_array[i], abs_path) == 0)
-        {
-            fprintf (stderr, "error: destination specified in earlier config: %s\n",
-                     abs_path);
-            free (abs_path);
-            return -1;
-        }
-    }
-
-    destination_array[(*dest_count)++] = abs_path;
     return 0;
 }
 
 static int
-validate_data (json_t *data, config_data *config, char **destination_array,
-               size_t *dest_count)
+validate_data (json_t *data, config_data *config)
 {
     json_t *query, *frequency, *destination, *max_samples, *max_size;
 
@@ -382,10 +363,9 @@ validate_data (json_t *data, config_data *config, char **destination_array,
         return -1;
     }
 
-    // if destionation already exists (or cant be made), gracefully reject.
-    if (validate_destination (destination, destination_array, dest_count) != 0)
+    if (validate_destination (destination) != 0)
     {
-        return 1;
+        return -1;
     }
 
     max_samples = json_object_get (data, "max_samples");
@@ -412,88 +392,184 @@ validate_data (json_t *data, config_data *config, char **destination_array,
 }
 
 static int
-initialise_configs (json_t *root)
+initialise_config (json_t *data)
 {
-    size_t i;
-    char **destination_array = malloc (json_array_size (root) * sizeof (char *));
-    size_t dest_count = 0;
-
-    for (i = 0; i < json_array_size (root); i++)
+    if (!json_is_object (data))
     {
-        json_t *data;
+        fprintf (stderr, "error: config is not a json object\n");
+        return -1;
+    }
 
-        data = json_array_get (root, i);
-        if (!json_is_object (data))
-        {
-            fprintf (stderr, "error: config set %d is not an object\n", (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
+    config_data *config = malloc (sizeof (config_data));
+    int result = validate_data (data, config);
 
-        config_data *config = malloc (sizeof (config_data));
-        int result = validate_data (data, config, destination_array, &dest_count);
-        if (result == -1)
+    if (result == -1)
+    {
+        fprintf (stderr, "error: bad value in config \n");
+        free (config);
+        return -1;
+    }
+
+    create_logrotate_config (config);
+    g_thread_new (NULL, thread_func, config);
+
+    return 0;
+}
+
+static int
+load_configs_from_directory (const char *config_dir)
+{
+    DIR *dir;
+    struct dirent *entry;
+    char *ext;
+    char *path;
+    json_t *root;
+    json_error_t error;
+
+    dir = opendir (config_dir);
+    if (!dir)
+    {
+        fprintf (stderr, "error: failed to open config directory: %s\n", config_dir);
+        return -1;
+    }
+
+    while ((entry = readdir (dir)) != NULL)
+    {
+        if (entry->d_type != DT_REG)
         {
-            fprintf (stderr, "error: bad value in config set %d \n", (int) (i + 1));
-            json_decref (root);
-            free (config);
-            return -1;
-        }
-        if (result == 1)
-        {
-            fprintf (stderr, "error: skipping config set %d \n", (int) (i + 1));
             continue;
         }
 
-        create_logrotate_config (config);
+        /* Only reads .json files */
+        ext = strrchr (entry->d_name, '.');
+        if ((ext == NULL) || (strcmp (ext, ".json") != 0))
+        {
+            continue;
+        }
+        path = g_strdup_printf ("%s/%s", config_dir, entry->d_name);
 
-        g_thread_new (NULL, thread_func, config);
+        root = json_load_file (path, 0, &error);
+        if (!root)
+        {
+            fprintf (stderr, "error: unable to open file: %s\n", path);
+            json_decref (root);
+            g_free (path);
+            return -1;
+        }
+
+        if (initialise_config (root) != 0)
+        {
+            fprintf (stderr, "error: failed to initialise config from file: %s\n",
+                        path);
+            json_decref (root);
+            g_free (path);
+            return -1;
+        }
     }
-
-    for (size_t i = 0; i < dest_count; i++)
-    {
-        free (destination_array[i]);
-    }
-    free (destination_array);
-
+    
+    closedir (dir);
     return 0;
+}
+
+
+void
+test_compare_json_deep_nulls ()
+{
+    CU_ASSERT_PTR_NULL (compare_json_deep (NULL, NULL));
+    
+    CU_ASSERT_EQUAL (compare_json_deep (NULL, json_object ()), json_null ());
+
+    json_t *old = json_object ();
+    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, NULL), old);
+    json_decref (old);
+}
+
+void
+test_compare_json_deep_different_types ()
+{
+    json_t *old = json_object ();
+    json_t *new = json_string ("new value");
+
+    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, new), old);
+
+    json_decref (old);
+    json_decref (new);
 }
 
 
 int
 main (int argc, char *argv[])
 {
+    int opt;
+    const char *config_dir = NULL;
+    bool unit_test = false;
+    CU_pSuite pSuite;
+    GMainLoop *main_loop = NULL;
+    
+    while ((opt = getopt (argc, argv, "huc:")) != -1)
+    {
+        switch (opt)
+        {
+            case 'u':
+                unit_test = true;
+                break;
+            case 'c':
+                config_dir = optarg;
+                break;
+            break;
+            case '?':
+            case 'h':
+            default:
+                printf ("Usage: %s [-h] [-u] [-c <configdir>]\n"
+                        "  -h   show this help\n"
+                        "  -u   run unit tests\n"
+                        "  -c   use files from <configdir>\n"
+                        ,argv[0]);
+                return 0;
+        }
+    }
+ 
+
+    if (unit_test)
+    {
+        CU_initialize_registry ();
+
+        pSuite = CU_add_suite("compare_json_deep units", NULL, NULL);
+        CU_add_test(pSuite, "NULL values", test_compare_json_deep_nulls);
+        CU_add_test(pSuite, "differing types", test_compare_json_deep_different_types);
+        
+        CU_basic_run_tests();
+        CU_cleanup_registry();
+
+        goto exit;
+    }
+
+
+    if (!config_dir)
+    {
+        fprintf (stderr, "error: No configuration directory path set. Missing -c <configdir>\n");
+        return -1;
+    }
+
     apteryx_init (false);
 
-    json_t *root;
-    json_error_t error;
-
-    if (argc != 2)
+    if (load_configs_from_directory (config_dir) != 0)
     {
-        fprintf (stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n", argv[0]);
-        fprintf (stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n");
-        return -1;
+        goto exit;
     }
 
-    root = json_load_file (argv[1], 0, &error);
-    if (!root)
-    {
-        fprintf (stderr, "error: unable to open file: %s\n", argv[1]);
-        return -1;
-    }
-
-    if (!json_is_array (root))
-    {
-        fprintf (stderr, "error: config is not an array\n");
-        json_decref (root);
-        return -1;
-    }
-
-    initialise_configs (root);
-    json_decref (root);
-
-    GMainLoop *main_loop = g_main_loop_new (NULL, false);
+    main_loop = g_main_loop_new (NULL, false);
     g_main_loop_run (main_loop);
+
+
+  exit:
+    if (main_loop)
+    {
+        g_main_loop_unref (main_loop);
+    }
+
+    /* Cleanup client library */
+    apteryx_shutdown ();
 
     return 0;
 }

--- a/recorder.c
+++ b/recorder.c
@@ -151,10 +151,8 @@ write_diff (json_t *current_json, const char *path_to_diff)
     if (!storage)
     {
         json_t *new_storage = json_object ();
+        json_object_set_new (new_storage, "timestamp", json_integer (time (NULL)));
         json_object_set_new (new_storage, "current", json_deep_copy (current_json));
-
-        json_object_set_new (diff, "timestamp", json_integer (time (NULL)));
-        json_object_set_new (diff, "changes", json_object ());
 
         json_t *diffs_array = json_array ();
         json_array_append_new (diffs_array, diff);
@@ -169,10 +167,11 @@ write_diff (json_t *current_json, const char *path_to_diff)
     json_t *changes =
         compare_json_deep (json_object_get (storage, "current"), current_json);
 
-    json_object_set_new (diff, "timestamp", json_integer (time (NULL)));
+    json_object_set_new (diff, "timestamp", json_deep_copy (json_object_get (storage, "timestamp")));
     json_object_set_new (diff, "changes", changes ? changes : json_object ());
 
     json_array_append_new (json_object_get (storage, "diffs"), diff);
+    json_object_set_new (storage, "timestamp", json_integer (time (NULL)));
     json_object_set_new (storage, "current", json_deep_copy (current_json));
 
     error_code = json_dump_file (storage, path_to_diff, JSON_INDENT (json_indent));

--- a/recorder.c
+++ b/recorder.c
@@ -21,7 +21,7 @@
 static const int path_buffer = 256;
 static const int json_indent = 2;
 
-static json_t *compare_json_deep(json_t *old_json, json_t *new_json);
+static json_t *compare_json_deep (json_t *old_json, json_t *new_json);
 
 typedef struct _config_data
 {
@@ -32,180 +32,171 @@ typedef struct _config_data
     long max_size;
     GMainLoop *loop;
 } config_data;
-                       
 
-json_t *gnode_to_json(const GNode *node)
+
+json_t *
+gnode_to_json (const GNode *node)
 {
-    json_t *obj = json_object();
-    if (!obj) return NULL;
+    json_t *obj = json_object ();
+    if (!obj)
+    {
+        return NULL;
+    }
 
     for (const GNode *child = node->children; child; child = child->next)
     {
         json_t *child_json = NULL;
-        if (APTERYX_HAS_VALUE(child))
+        if (APTERYX_HAS_VALUE (child))
         {
-            child_json = json_string(APTERYX_VALUE(child));
+            child_json = json_string (APTERYX_VALUE (child));
         }
         else
         {
-            child_json = gnode_to_json(child);
+            child_json = gnode_to_json (child);
             if (!child_json)
             {
-                json_decref(obj);
+                json_decref (obj);
                 return NULL;
             }
         }
 
-        json_object_set_new(obj, (char*)child->data, child_json);
+        json_object_set_new (obj, (char *) child->data, child_json);
     }
 
     return obj;
 }
 
-static int make_path(char *path)
+static int
+make_path (char *path)
 {
-    char *p = path + (*path == '/');  // Skip leading /
-    while ((p = strchr(p, '/')))
+    char *p = path + (*path == '/');    // Skip leading /
+    while ((p = strchr (p, '/')))
     {
         *p = '\0';
-        if (mkdir(path, 0755) && errno != EEXIST) return -1;
+        if (mkdir (path, 0755) && errno != EEXIST)
+        {
+            return -1;
+        }
         *p++ = '/';
     }
     return 0;
 }
 
 
-static json_t *compare_objects(json_t *old_obj, json_t *new_obj)
+static json_t *
+compare_objects (json_t *old_obj, json_t *new_obj)
 {
-    json_t *changes = json_object();
+    json_t *changes = json_object ();
     const char *key;
     json_t *value;
-    
-    json_object_foreach(old_obj, key, value)
+
+    json_object_foreach (old_obj, key, value)
     {
-        json_t *diff = compare_json_deep(value, json_object_get(new_obj, key));
-        if (diff) json_object_set_new(changes, key, diff);
-    }
-    
-    json_object_foreach(new_obj, key, value)
-    {
-        if (!json_object_get(old_obj, key))
+        json_t *diff = compare_json_deep (value, json_object_get (new_obj, key));
+        if (diff)
         {
-            json_object_set_new(changes, key, json_null());
+            json_object_set_new (changes, key, diff);
         }
     }
 
-    if (!json_object_size(changes))
+    json_object_foreach (new_obj, key, value)
     {
-        json_decref(changes);
+        if (!json_object_get (old_obj, key))
+        {
+            json_object_set_new (changes, key, json_null ());
+        }
+    }
+
+    if (!json_object_size (changes))
+    {
+        json_decref (changes);
         return NULL;
     }
     return changes;
 }
 
-static json_t *compare_arrays(const json_t *old_arr, const json_t *new_arr)
+static json_t *
+compare_json_deep (json_t *old_json, json_t *new_json)
 {
-    size_t old_size = json_array_size(old_arr);
-    size_t new_size = json_array_size(new_arr);
-    size_t max_size = old_size > new_size ? old_size : new_size;
-
-    json_t *changes = json_array();
-    gboolean has_changes = FALSE;
-    
-    for (size_t i = 0; i < max_size; i++)
-    {       
-        json_t *old_elem = i < old_size ? json_array_get(old_arr, i) : json_null();
-        json_t *new_elem = i < new_size ? json_array_get(new_arr, i) : json_null();
-        json_t *diff = compare_json_deep(old_elem, new_elem);
-
-        // Always append to maintain index alignment
-        json_array_append_new(changes, diff ? diff : json_null());
-        if (diff) has_changes = TRUE;
-    }
-
-    if (!has_changes)
+    if (!old_json && !new_json)
     {
-        json_decref(changes);
         return NULL;
     }
-    return changes;
+    if (!old_json)
+    {
+        return json_null ();
+    }
+    if (!new_json)
+    {
+        return json_incref (old_json);
+    }
+
+    if (json_typeof (old_json) != json_typeof (new_json) ||
+        json_typeof (old_json) != JSON_OBJECT)
+    {
+        return json_equal (old_json, new_json) ? NULL : json_incref (old_json);
+    }
+
+    return compare_objects (old_json, new_json);
 }
 
-// Compares objects based on their type
-static json_t *compare_json_deep(json_t *old_json, json_t *new_json)
-{
-    if (!old_json && !new_json) return NULL;
-    if (!old_json) return json_null();
-    if (!new_json) return json_incref(old_json);
-    
-    // Cant easily compare different types
-    if (json_typeof(old_json) != json_typeof(new_json))
-    {
-        return json_incref(old_json);
-    }
-    
-    switch (json_typeof(old_json))
-    {
-        case JSON_OBJECT: return compare_objects(old_json, new_json);
-        case JSON_ARRAY: return compare_arrays(old_json, new_json);
-        default: return json_equal(old_json, new_json) ? NULL : json_incref(old_json);
-    }
-}
-
-static int write_diff(json_t *current_json, const char* path_to_diff)
+static int
+write_diff (json_t *current_json, const char *path_to_diff)
 {
     int error_code;
     json_error_t error;
-    json_t *storage = json_load_file(path_to_diff, 0, &error);
-    json_t *diff = json_object();
-   
+    json_t *storage = json_load_file (path_to_diff, 0, &error);
+    json_t *diff = json_object ();
+
     if (!storage)
     {
-        json_t *new_storage = json_object();
-        json_object_set_new(new_storage, "current", json_deep_copy(current_json));
-        
-        json_object_set_new(diff, "timestamp", json_integer(time(NULL)));
-        json_object_set_new(diff, "changes", json_object());
-        
-        json_t *diffs_array = json_array();
-        json_array_append_new(diffs_array, diff);
-        json_object_set_new(new_storage, "diffs", diffs_array);
-        
-        error_code = json_dump_file(new_storage, path_to_diff, JSON_INDENT(json_indent));
-        json_decref(new_storage);
+        json_t *new_storage = json_object ();
+        json_object_set_new (new_storage, "current", json_deep_copy (current_json));
+
+        json_object_set_new (diff, "timestamp", json_integer (time (NULL)));
+        json_object_set_new (diff, "changes", json_object ());
+
+        json_t *diffs_array = json_array ();
+        json_array_append_new (diffs_array, diff);
+        json_object_set_new (new_storage, "diffs", diffs_array);
+
+        error_code = json_dump_file (new_storage, path_to_diff, JSON_INDENT (json_indent));
+        json_decref (new_storage);
 
         return error_code;
     }
-    
-    json_t *changes = compare_json_deep(json_object_get(storage, "current"), current_json);
-    
-    json_object_set_new(diff, "timestamp", json_integer(time(NULL)));
-    json_object_set_new(diff, "changes", changes ? changes : json_object());
-    
-    json_array_append_new(json_object_get(storage, "diffs"), diff);
-    json_object_set_new(storage, "current", json_deep_copy(current_json));
-    
-    error_code = json_dump_file(storage, path_to_diff, JSON_INDENT(json_indent));
-    json_decref(storage);
-    
+
+    json_t *changes =
+        compare_json_deep (json_object_get (storage, "current"), current_json);
+
+    json_object_set_new (diff, "timestamp", json_integer (time (NULL)));
+    json_object_set_new (diff, "changes", changes ? changes : json_object ());
+
+    json_array_append_new (json_object_get (storage, "diffs"), diff);
+    json_object_set_new (storage, "current", json_deep_copy (current_json));
+
+    error_code = json_dump_file (storage, path_to_diff, JSON_INDENT (json_indent));
+    json_decref (storage);
+
     return error_code;
 }
 
 
 // Creates a unique name for logrotate conf based on destination
-static char* sanitize_path_for_config(const char *path)
+static char *
+sanitize_path_for_config (const char *path)
 {
-    char *result = malloc(strlen(path) + 7);
-    strcpy(result, "config-");
+    char *result = malloc (strlen (path) + 7);
+    strcpy (result, "config-");
     char *dst = result + 7;
-    
+
     for (const char *src = path; *src; src++)
     {
         if (*src == '/' || *src == '.')
         {
             *dst++ = '-';
-        } 
-        else if (isalnum(*src) || *src == '_') 
+        }
+        else if (isalnum (*src) || *src == '_')
         {
             *dst++ = *src;
         }
@@ -215,233 +206,248 @@ static char* sanitize_path_for_config(const char *path)
     return result;
 }
 
-static char* resolve_absolute_path(const char *path)
+static char *
+resolve_absolute_path (const char *path)
 {
     // If full path already exists, resolve directly
-    char *resolved = realpath(path, NULL);
-    if (resolved) return resolved;
+    char *resolved = realpath (path, NULL);
+    if (resolved)
+    {
+        return resolved;
+    }
 
     // If there is no file, resolve parent directory instead (& append name)
-    char *path_copy = strdup(path);
-    char *resolved_dir = realpath(dirname(path_copy), NULL);
-    free(path_copy);
+    char *path_copy = strdup (path);
+    char *resolved_dir = realpath (dirname (path_copy), NULL);
+    free (path_copy);
 
-    if (!resolved_dir) return NULL;
+    if (!resolved_dir)
+    {
+        return NULL;
+    }
 
-    path_copy = strdup(path);
-    char *result = malloc(strlen(resolved_dir) + strlen(basename(path_copy)) + 2);
-    sprintf(result, "%s/%s", resolved_dir, basename(path_copy));
+    path_copy = strdup (path);
+    char *result = malloc (strlen (resolved_dir) + strlen (basename (path_copy)) + 2);
+    sprintf (result, "%s/%s", resolved_dir, basename (path_copy));
 
-    free(path_copy);
-    free(resolved_dir);
+    free (path_copy);
+    free (resolved_dir);
     return result;
 }
 
-static void create_logrotate_config(config_data *config)
+static void
+create_logrotate_config (config_data *config)
 {
-    char *absolute_path = resolve_absolute_path(config->destination);
+    char *absolute_path = resolve_absolute_path (config->destination);
     if (!absolute_path)
     {
-        fprintf(stderr, "error: failed to resolve path: %s\n", config->destination);
+        fprintf (stderr, "error: failed to resolve path: %s\n", config->destination);
         return;
     }
-    
-    char *config_name = sanitize_path_for_config(config->destination);
+
+    char *config_name = sanitize_path_for_config (config->destination);
     char config_path[path_buffer];
-    snprintf(config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
-    
-    FILE *f = fopen(config_path, "w");
+    snprintf (config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
+
+    FILE *f = fopen (config_path, "w");
     if (!f)
     {
-        fprintf(stderr, "error: failed to create logrotate config: %s\n", config_path);
-        free(absolute_path);
-        free(config_name);
+        fprintf (stderr, "error: failed to create logrotate config: %s\n", config_path);
+        free (absolute_path);
+        free (config_name);
         return;
     }
-    
-    fprintf(f, "%s {\n", absolute_path);
-    fprintf(f, "    size %ldM\n", config->max_size);
-    fprintf(f, "    rotate %d\n", config->max_samples);
-    fprintf(f, "    missingok\n");
-    fprintf(f, "    notifempty\n");
-    fprintf(f, "    nocreate\n");
-    fprintf(f, "}\n");
-    
-    fclose(f);
-    free(absolute_path);
-    free(config_name);
+
+    fprintf (f, "%s {\n", absolute_path);
+    fprintf (f, "    size %ldM\n", config->max_size);
+    fprintf (f, "    rotate %d\n", config->max_samples);
+    fprintf (f, "    missingok\n");
+    fprintf (f, "    notifempty\n");
+    fprintf (f, "    nocreate\n");
+    fprintf (f, "}\n");
+
+    fclose (f);
+    free (absolute_path);
+    free (config_name);
 }
 
 
-static gboolean polling_callback(gpointer user_data)
+static gboolean
+polling_callback (gpointer user_data)
 {
-    config_data *config = (config_data *)user_data;
+    config_data *config = (config_data *) user_data;
 
-    GNode *tree = apteryx_query (g_node_new (config->query));
-        
-    json_t *json_from_tree = tree ? gnode_to_json(tree) : NULL;
+    GNode *root = g_node_new (g_strdup ("/"));
+    apteryx_query_to_node (root, config->query);
+    GNode *tree = apteryx_query (root);
+    apteryx_free_tree (root);
+
+    json_t *json_from_tree = tree ? gnode_to_json (tree) : NULL;
     apteryx_free_tree (tree);
 
     if (!json_from_tree)
     {
-        fprintf(stderr, "error: could not fetch JSON from query: %s\n", config->query);
+        fprintf (stderr, "error: could not fetch JSON from query: %s\n", config->query);
         return G_SOURCE_CONTINUE;
     }
-    
-    if (write_diff(json_from_tree, config->destination) != 0)
+
+    if (write_diff (json_from_tree, config->destination) != 0)
     {
-        fprintf(stderr, "error: could not write diff. Check destination: %s\n", config->destination);
-        json_decref(json_from_tree);
+        fprintf (stderr, "error: could not write diff. Check destination: %s\n",
+                 config->destination);
+        json_decref (json_from_tree);
         return G_SOURCE_REMOVE;
-    }    
-    
-    json_decref(json_from_tree);
-    
+    }
+
+    json_decref (json_from_tree);
+
     return G_SOURCE_CONTINUE;
 }
 
-static gpointer thread_func(gpointer user_data)
+static gpointer
+thread_func (gpointer user_data)
 {
-    config_data *config = (config_data *)user_data;
-    
-    GMainContext *context = g_main_context_new();
-    config->loop = g_main_loop_new(context, FALSE);
+    config_data *config = (config_data *) user_data;
 
-    g_main_context_push_thread_default(context);
-    
-    GSource *timeout = g_timeout_source_new_seconds(config->frequency);
-    g_source_set_callback(timeout, polling_callback, config, NULL);
-    g_source_attach(timeout, context);
-    g_source_unref(timeout);
-    
-    g_main_loop_run(config->loop);
-    
-    g_main_context_pop_thread_default(context);
-    g_main_context_unref(context);
-    
+    GMainContext *context = g_main_context_new ();
+    config->loop = g_main_loop_new (context, FALSE);
+
+    g_main_context_push_thread_default (context);
+
+    GSource *timeout = g_timeout_source_new_seconds (config->frequency);
+    g_source_set_callback (timeout, polling_callback, config, NULL);
+    g_source_attach (timeout, context);
+    g_source_unref (timeout);
+
+    g_main_loop_run (config->loop);
+
+    g_main_context_pop_thread_default (context);
+    g_main_context_unref (context);
+
     return NULL;
 }
 
 
-static int initialise_configs(json_t *root)
+static int
+initialise_configs (json_t *root)
 {
     size_t i;
 
-    for(i = 0; i < json_array_size(root); i++)
+    for (i = 0; i < json_array_size (root); i++)
     {
-        // TODO: Verify data. e.g. unique dest(?), limits on freq/max values
-        // What to do if an identical query is attempted? Prefer more frequent or older?
         json_t *data, *query, *frequency, *destination, *max_samples, *max_size;
-        //  "query": "/test/*/tests",
-        // "frequency": "30"(s),
-        // "max_samples": "10",
-        // "max_size": "32000"(MB),
-        // "destination": "/dest"
 
-        data = json_array_get(root, i);
-        if(!json_is_object(data))
+        data = json_array_get (root, i);
+        if (!json_is_object (data))
         {
-            fprintf(stderr, "error: config set %d is not an object\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d is not an object\n", (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        query = json_object_get(data, "query");
-        if(!json_is_string(query)) 
+        query = json_object_get (data, "query");
+        if (!json_is_string (query))
         {
-            fprintf(stderr, "error: config set %d: query is not a string\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d: query is not a string\n",
+                     (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        frequency = json_object_get(data, "frequency");
-        if(!json_is_integer(frequency))
+        frequency = json_object_get (data, "frequency");
+        if (!json_is_integer (frequency))
         {
-            fprintf(stderr, "error: config set %d: frequency is not an integer\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d: frequency is not an integer\n",
+                     (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        destination = json_object_get(data, "destination");
-        if(!json_is_string(destination))
+        destination = json_object_get (data, "destination");
+        if (!json_is_string (destination))
         {
-            fprintf(stderr, "error: config set %d: destination is not a string\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d: destination is not a string\n",
+                     (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        max_samples = json_object_get(data, "max_samples");
-        if(!json_is_integer(max_samples))
+        max_samples = json_object_get (data, "max_samples");
+        if (!json_is_integer (max_samples))
         {
-            fprintf(stderr, "error: config set %d: max_samples is not an integer\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d: max_samples is not an integer\n",
+                     (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        max_size = json_object_get(data, "max_size");
-        if(!json_is_integer(max_size))
+        max_size = json_object_get (data, "max_size");
+        if (!json_is_integer (max_size))
         {
-            fprintf(stderr, "error: config set %d: max_size is not an integer\n", (int)(i + 1));
-            json_decref(root);
+            fprintf (stderr, "error: config set %d: max_size is not an integer\n",
+                     (int) (i + 1));
+            json_decref (root);
             return -1;
         }
 
-        config_data *config = malloc(sizeof(config_data));
-        config->query = strdup(json_string_value(query));
-        config->frequency = json_integer_value(frequency);
-        config->destination = strdup(json_string_value(destination));
-        config->max_samples = json_integer_value(max_samples);
-        config->max_size = json_integer_value(max_size);
+        config_data *config = malloc (sizeof (config_data));
+        config->query = strdup (json_string_value (query));
+        config->frequency = json_integer_value (frequency);
+        config->destination = strdup (json_string_value (destination));
+        config->max_samples = json_integer_value (max_samples);
+        config->max_size = json_integer_value (max_size);
 
         // attempt to make destination path before calling logrotate
-        if(make_path(config->destination) != 0)
+        if (make_path (config->destination) != 0)
         {
-            fprintf(stderr, "error: failed to create specified path: %s\n", config->destination);
+            fprintf (stderr, "error: failed to create specified path: %s\n",
+                     config->destination);
             return -1;
         }
 
-        create_logrotate_config(config);
+        create_logrotate_config (config);
 
-        g_thread_new(NULL, thread_func, config);
+        g_thread_new (NULL, thread_func, config);
     }
 
     return 0;
 }
 
 
-int main(int argc, char *argv[])
+int
+main (int argc, char *argv[])
 {
-    apteryx_init(false);
+    apteryx_init (false);
 
     json_t *root;
     json_error_t error;
 
-    if(argc != 2)
+    if (argc != 2)
     {
-        fprintf(stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n", argv[0]);
-        fprintf(stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n");
+        fprintf (stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n", argv[0]);
+        fprintf (stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n");
         return -1;
     }
 
-    root = json_load_file(argv[1], 0, &error);
-    if(!root)
+    root = json_load_file (argv[1], 0, &error);
+    if (!root)
     {
-        fprintf(stderr, "error: unable to open file: %s\n", argv[1]);
+        fprintf (stderr, "error: unable to open file: %s\n", argv[1]);
         return -1;
     }
 
-    if(!json_is_array(root))
+    if (!json_is_array (root))
     {
-        fprintf(stderr, "error: config is not an array\n");
-        json_decref(root);
+        fprintf (stderr, "error: config is not an array\n");
+        json_decref (root);
         return -1;
     }
 
-    initialise_configs(root);
-    json_decref(root);
+    initialise_configs (root);
+    json_decref (root);
 
-    GMainLoop *main_loop = g_main_loop_new(NULL, false);
-    g_main_loop_run(main_loop);
+    GMainLoop *main_loop = g_main_loop_new (NULL, false);
+    g_main_loop_run (main_loop);
 
     return 0;
 }

--- a/recorder.c
+++ b/recorder.c
@@ -155,7 +155,6 @@ write_diff (json_t *current_json, const char *path_to_diff)
         json_object_set_new (new_storage, "current", json_deep_copy (current_json));
 
         json_t *diffs_array = json_array ();
-        json_array_append_new (diffs_array, diff);
         json_object_set_new (new_storage, "diffs", diffs_array);
 
         error_code = json_dump_file (new_storage, path_to_diff, JSON_INDENT (json_indent));
@@ -171,7 +170,7 @@ write_diff (json_t *current_json, const char *path_to_diff)
                          json_deep_copy (json_object_get (storage, "timestamp")));
     json_object_set_new (diff, "changes", changes ? changes : json_object ());
 
-    json_array_append_new (json_object_get (storage, "diffs"), diff);
+    json_array_insert_new (json_object_get (storage, "diffs"), 0, diff);
     json_object_set_new (storage, "timestamp", json_integer (time (NULL)));
     json_object_set_new (storage, "current", json_deep_copy (current_json));
 

--- a/recorder.c
+++ b/recorder.c
@@ -1,0 +1,446 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <dirent.h>
+#include <apteryx.h>
+#include <glib-unix.h>
+#include <apteryx-xml.h>
+#include <syslog.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <time.h>
+#include <jansson.h>
+#include "common.h"
+#include "apteryx_sync.h"
+
+static const int path_buffer = 256;
+static const int index_buffer = 32;
+static const int json_indent = 2;
+
+static void compare_json_deep(json_t *old_json, json_t *new_json, 
+                               const char *path_prefix, json_t *changes);
+// FIXME: Make errors & general style consistent with other ATL/ Apteryx... e.g. error codes...
+
+// FIXME: Replace w/ json_load_file?
+static char* load_file(const char* filename) {
+    FILE* f = fopen(filename, "r");
+    if (!f) return NULL;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    rewind(f);
+
+    char *buffer = malloc(size + 1);
+    if (buffer)
+    {
+        long bytes_read = fread(buffer, 1, size, f);
+        if (bytes_read < size) return NULL; // File was not completely read...
+        buffer[size] = '\0';
+    }
+    fclose(f);
+    return buffer;
+}
+
+// FIXME: Function decomp
+// static int read_text(char* json_text, json_t* root) {
+//     json_error_t error;
+//     json_t *temp_root;
+
+
+//     temp_root = json_loads(json_text, 0, &error);
+//     free(json_text);
+
+
+//     if(!temp_root)
+//     {
+//         fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
+//         return 0;
+//     }
+
+//     if(!json_is_array(temp_root))
+//     {
+//         fprintf(stderr, "error: root is not an array\n");
+//         json_decref(temp_root);
+//         return 0;
+//     }
+
+//     *root = *temp_root;
+
+//     return 1;
+// }
+
+
+json_t *gnode_to_json(const GNode *node)
+{
+    json_t *obj = json_object();
+    if (!obj) return NULL;
+
+    for (const GNode *child = node->children;
+         child;
+         child = child->next)
+    {
+
+        json_t *child_json = NULL;
+        if (APTERYX_HAS_VALUE(child))
+        {
+            child_json = json_string(APTERYX_VALUE(child));
+        }
+        else
+        {
+            child_json = gnode_to_json(child);
+            if (!child_json) {
+                json_decref(obj);
+                return NULL;
+            }
+        }
+
+        json_object_set_new(obj, (char*)child->data, child_json);
+    }
+
+    return obj;
+}
+
+static int make_dir(const char *path)
+{
+    if (mkdir(path, 0600) == -1)
+    {
+        if (errno == EEXIST)
+        {
+            printf("Directory already exists.\n");
+        }
+        else
+        {
+            perror("mkdir failed");
+        }
+    }
+    else
+    {
+        printf("Directory created successfully.\n");
+    }
+}
+
+
+
+// TODO: Change dot notation to be more like actual tree... 
+// Uses dot notation for children/indices. e.g. parent.child.0
+static void build_path(char *buffer, size_t size, const char *prefix, const char *key)
+{
+    if (strlen(prefix) == 0)
+    {
+        snprintf(buffer, size, "%s", key);
+    }
+    else
+    {
+        snprintf(buffer, size, "%s.%s", prefix, key);
+    }
+}
+
+// FIXME(?): json foreach/set discards const....
+    // I assume its better to keep const and suppress warnings...
+
+// FIXME: Optimise option...
+    // void *iter = json_object_iter((json_t*)new_obj);
+    // while (iter) {
+    //     const char *key = json_object_iter_key(iter);
+    //     json_t *old_val = json_object_get(old_obj, key);
+    //     json_t *new_val = json_object_iter_value(iter);
+    //     // compare and mark new keys
+    //     iter = json_object_iter_next((json_t*)new_obj, iter);
+    // }
+    // // Then iterate old_obj only for removed keys
+// Compares JSON objects
+static void compare_objects(json_t *old_obj, json_t *new_obj,
+                           const char *path_prefix, json_t *changes)
+{
+    const char *key;
+    json_t *value;
+    
+    json_object_foreach(old_obj, key, value)
+    {
+        char new_path[path_buffer];
+        build_path(new_path, sizeof(new_path), path_prefix, key);
+        
+        printf("My KEY is: %s", key);
+        
+        json_t *new_value = json_object_get(new_obj, key);
+        compare_json_deep(value, new_value, new_path, changes);
+    }
+    
+    // This is needed to find NEW keys (thus causing NULLs in the diff)
+    json_object_foreach(new_obj, key, value)
+    {
+        if (!json_object_get(old_obj, key))
+        {
+            char new_path[path_buffer];
+            build_path(new_path, sizeof(new_path), path_prefix, key);
+            json_object_set_new(changes, new_path, json_null());
+        }
+    }
+}
+
+static void compare_arrays(const json_t *old_arr, const json_t *new_arr,
+                          const char *path_prefix, json_t *changes)
+{
+    size_t old_size = json_array_size(old_arr);
+    size_t new_size = json_array_size(new_arr);
+    size_t max_size = old_size > new_size ? old_size : new_size;
+    
+    for (size_t i = 0; i < max_size; i++)
+    {
+        char index_str[index_buffer];
+        snprintf(index_str, sizeof(index_str), "%zu", i);
+        
+        char new_path[path_buffer];
+        build_path(new_path, sizeof(new_path), path_prefix, index_str);
+        
+        json_t *old_elem = i < old_size ? json_array_get(old_arr, i) : json_null();
+        json_t *new_elem = i < new_size ? json_array_get(new_arr, i) : json_null();
+        
+        compare_json_deep(old_elem, new_elem, new_path, changes);
+    }
+}
+
+// Compares objects based on their type
+static void compare_json_deep(json_t *old_json, json_t *new_json, 
+                               const char *path_prefix, json_t *changes)
+{
+    if (!old_json && !new_json) return;
+    
+    if (!old_json && new_json)
+    {
+        json_object_set_new(changes, path_prefix, json_null());
+        return;
+    }
+    
+    if (old_json && !new_json)
+    {
+        json_object_set(changes, path_prefix, old_json);
+        return;
+    }
+    
+    // Cant easily compare different types
+    if (json_typeof(old_json) != json_typeof(new_json))
+    {
+        json_object_set(changes, path_prefix, old_json);
+        return;
+    }
+    
+    switch (json_typeof(old_json))
+    {
+        case JSON_OBJECT:
+            compare_objects(old_json, new_json, path_prefix, changes);
+            break;
+        case JSON_ARRAY:
+            compare_arrays(old_json, new_json, path_prefix, changes);
+            break;
+        default: // E.g. string / num / bool
+            if (!json_equal(old_json, new_json))
+            {
+                json_object_set(changes, path_prefix, old_json);
+            }
+            break;
+    }
+}
+
+static int write_diff(json_t *current_json, const char* path_to_diff)
+{
+    int error_code;
+    json_error_t error;
+    json_t *storage = json_load_file(path_to_diff, 0, &error);
+   
+    if (!storage)
+    {
+
+        // attempt to make the path before creating the JSON
+        if(!make_dir(path_to_diff)) return 0;
+
+        json_t *new_storage = json_object();
+        json_object_set_new(new_storage, "current", json_deep_copy(current_json));
+        
+        json_t *diffs_array = json_array();
+        json_t *initial_diff = json_object();
+        json_object_set_new(initial_diff, "timestamp", json_integer(time(NULL)));
+        json_object_set_new(initial_diff, "changes", json_object());
+        json_array_append_new(diffs_array, initial_diff);
+        
+        json_object_set_new(new_storage, "diffs", diffs_array);
+        
+        error_code = json_dump_file(new_storage, path_to_diff, JSON_INDENT(json_indent));
+        json_decref(new_storage);
+
+        if (error_code != 0) return 0;
+
+        return 1;
+    }
+    
+    json_t *old_current = json_object_get(storage, "current");
+    json_t *changes = json_object();
+    compare_json_deep(old_current, current_json, "", changes);
+    
+    json_t *new_diff = json_object();
+    json_object_set_new(new_diff, "timestamp", json_integer(time(NULL))); // Should timestamp be earlier?
+    json_object_set_new(new_diff, "changes", changes);
+    
+    json_t *diffs_array = json_object_get(storage, "diffs");
+    json_array_append_new(diffs_array, new_diff);
+    
+    json_object_set_new(storage, "current", json_deep_copy(current_json));
+    
+    error_code = json_dump_file(storage, path_to_diff, JSON_INDENT(json_indent));
+    json_decref(storage);
+
+    if (error_code != 0) return 0;
+    
+    return 1;
+}
+
+
+
+int main(int argc, char *argv[])
+{
+    apteryx_init(false);
+
+    size_t i;
+    char *text;
+    json_t *root = NULL;
+
+    if(argc != 1)
+    {
+        fprintf(stderr, "usage: %s USER REPOSITORY\n\n", argv[0]);
+        fprintf(stderr, "List commits at USER's REPOSITORY.\n\n");
+        return -1;
+    }
+
+    text = load_file("test.json");
+    if(!text) {
+        fprintf(stderr, "error: unable to open file.");
+        return 0;
+    }
+
+
+    // FIXME: Put into separate function
+    json_error_t error;
+
+    root = json_loads(text, 0, &error);
+    free(text);
+
+    if(!root)
+    {
+        fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
+        return 0;
+    }
+
+    if(!json_is_array(root))
+    {
+        fprintf(stderr, "error: root is not an array\n");
+        json_decref(root);
+        return 0;
+    }
+
+    // if (!read_text(text, root)) {
+    //     fprintf(stderr, "Error: unable to read file as JSON.");
+    //     return 0;
+    // }
+
+    if(!root){
+        fprintf(stderr, "Erdfdfror: unable to read file as JSON.");
+        return 0;
+    }
+
+    
+  
+
+
+    // FIXME: Put into separate functionS
+    for(i = 0; i < json_array_size(root); i++)
+    {
+        json_t *data, *query, *frequency, *destination, *max_samples, *max_size;
+        //  "query": "/test/*/tests",
+        // "frequency": "30"(s),
+        // "max_samples": "10",
+        // "max_size": "32000"(MB),
+        // "destination": "/dest"
+
+        data = json_array_get(root, i);
+        if(!json_is_object(data))
+        {
+            fprintf(stderr, "error: config set %d is not an object\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        query = json_object_get(data, "query");
+        if(!json_is_string(query)) 
+        {
+            fprintf(stderr, "error: config set %d: query is not a string\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        frequency = json_object_get(data, "frequency");
+        if(!json_is_integer(frequency))
+        {
+            fprintf(stderr, "error: config set %d: frequency is not an integer\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        destination = json_object_get(data, "destination");
+        if(!json_is_string(destination))
+        {
+            fprintf(stderr, "error: config set %d: destination is not a string\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        max_samples = json_object_get(data, "max_samples");
+        if(!json_is_integer(max_samples))
+        {
+            fprintf(stderr, "error: config set %d: max_samples is not an integer\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        max_size = json_object_get(data, "max_size");
+        if(!json_is_integer(max_size))
+        {
+            fprintf(stderr, "error: config set %d: max_size is not an integer\n", (int)(i + 1));
+            json_decref(root);
+            return 1;
+        }
+
+        // TODO: Make a new thread for EACH config file: give it relevant config info
+        // FIXME: Put into separate function
+        char *query_text;
+        query_text = strdup(json_string_value(query));
+        
+        printf("s %s  TO %s\n",
+            query_text, 
+            json_string_value(destination)
+            );
+
+        GNode *gquery = g_node_new (query_text); 
+        GNode *tree = apteryx_query(gquery); // FIXME: Prevent segfaults from bad queries...
+        json_t *json_from_tree = gnode_to_json(tree);
+
+        if (json_from_tree)
+        {
+            if (write_diff(json_from_tree, json_string_value(destination)) != 1)
+            {
+                printf("error: could not complete diff calculation. Check destination.\n");
+                return 0;
+            }
+
+            json_decref(json_from_tree);
+            apteryx_free_tree (tree);
+        } else {
+            printf("error: could not fetch JSON from query. Is it empty?\n");
+        }
+    }
+
+    json_decref(root);
+    return 0;
+}

--- a/recorder.c
+++ b/recorder.c
@@ -167,7 +167,8 @@ write_diff (json_t *current_json, const char *path_to_diff)
     json_t *changes =
         compare_json_deep (json_object_get (storage, "current"), current_json);
 
-    json_object_set_new (diff, "timestamp", json_deep_copy (json_object_get (storage, "timestamp")));
+    json_object_set_new (diff, "timestamp",
+                         json_deep_copy (json_object_get (storage, "timestamp")));
     json_object_set_new (diff, "changes", changes ? changes : json_object ());
 
     json_array_append_new (json_object_get (storage, "diffs"), diff);
@@ -328,13 +329,99 @@ thread_func (gpointer user_data)
 
 
 static int
+validate_destination (json_t *destination, char **destination_array, size_t *dest_count)
+{
+    char *dest_str = strdup (json_string_value (destination));
+
+    if (make_path (dest_str) != 0)
+    {
+        fprintf (stderr, "error: failed to create specified path: %s\n", dest_str);
+        return -1;
+    }
+
+    char *abs_path = resolve_absolute_path (dest_str);
+
+    for (size_t i = 0; i < *dest_count; i++)
+    {
+        if (strcmp (destination_array[i], abs_path) == 0)
+        {
+            fprintf (stderr, "error: destination specified in earlier config: %s\n",
+                     abs_path);
+            free (abs_path);
+            return -1;
+        }
+    }
+
+    destination_array[(*dest_count)++] = abs_path;
+    return 0;
+}
+
+static int
+validate_data (json_t *data, config_data *config, char **destination_array,
+               size_t *dest_count)
+{
+    json_t *query, *frequency, *destination, *max_samples, *max_size;
+
+    query = json_object_get (data, "query");
+    if (!json_is_string (query))
+    {
+        fprintf (stderr, "error: query is not a string\n");
+        return -1;
+    }
+
+    frequency = json_object_get (data, "frequency");
+    if (!json_is_integer (frequency))
+    {
+        fprintf (stderr, "error: frequency is not an integer\n");
+        return -1;
+    }
+
+    destination = json_object_get (data, "destination");
+    if (!json_is_string (destination))
+    {
+        fprintf (stderr, "error: destination is not a string\n");
+        return -1;
+    }
+
+    // if destionation already exists (or cant be made), gracefully reject.
+    if (validate_destination (destination, destination_array, dest_count) != 0)
+    {
+        return 1;
+    }
+
+    max_samples = json_object_get (data, "max_samples");
+    if (!json_is_integer (max_samples))
+    {
+        fprintf (stderr, "error: max_samples is not an integer\n");
+        return -1;
+    }
+
+    max_size = json_object_get (data, "max_size");
+    if (!json_is_integer (max_size))
+    {
+        fprintf (stderr, "error: max_size is not an integer\n");
+        return -1;
+    }
+
+    config->query = strdup (json_string_value (query));
+    config->frequency = json_integer_value (frequency);
+    config->destination = strdup (json_string_value (destination));
+    config->max_samples = json_integer_value (max_samples);
+    config->max_size = json_integer_value (max_size);
+
+    return 0;
+}
+
+static int
 initialise_configs (json_t *root)
 {
     size_t i;
+    char **destination_array = malloc (json_array_size (root) * sizeof (char *));
+    size_t dest_count = 0;
 
     for (i = 0; i < json_array_size (root); i++)
     {
-        json_t *data, *query, *frequency, *destination, *max_samples, *max_size;
+        json_t *data;
 
         data = json_array_get (root, i);
         if (!json_is_object (data))
@@ -344,70 +431,31 @@ initialise_configs (json_t *root)
             return -1;
         }
 
-        query = json_object_get (data, "query");
-        if (!json_is_string (query))
-        {
-            fprintf (stderr, "error: config set %d: query is not a string\n",
-                     (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
-
-        frequency = json_object_get (data, "frequency");
-        if (!json_is_integer (frequency))
-        {
-            fprintf (stderr, "error: config set %d: frequency is not an integer\n",
-                     (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
-
-        destination = json_object_get (data, "destination");
-        if (!json_is_string (destination))
-        {
-            fprintf (stderr, "error: config set %d: destination is not a string\n",
-                     (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
-
-        max_samples = json_object_get (data, "max_samples");
-        if (!json_is_integer (max_samples))
-        {
-            fprintf (stderr, "error: config set %d: max_samples is not an integer\n",
-                     (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
-
-        max_size = json_object_get (data, "max_size");
-        if (!json_is_integer (max_size))
-        {
-            fprintf (stderr, "error: config set %d: max_size is not an integer\n",
-                     (int) (i + 1));
-            json_decref (root);
-            return -1;
-        }
-
         config_data *config = malloc (sizeof (config_data));
-        config->query = strdup (json_string_value (query));
-        config->frequency = json_integer_value (frequency);
-        config->destination = strdup (json_string_value (destination));
-        config->max_samples = json_integer_value (max_samples);
-        config->max_size = json_integer_value (max_size);
-
-        // attempt to make destination path before calling logrotate
-        if (make_path (config->destination) != 0)
+        int result = validate_data (data, config, destination_array, &dest_count);
+        if (result == -1)
         {
-            fprintf (stderr, "error: failed to create specified path: %s\n",
-                     config->destination);
+            fprintf (stderr, "error: bad value in config set %d \n", (int) (i + 1));
+            json_decref (root);
+            free (config);
             return -1;
+        }
+        if (result == 1)
+        {
+            fprintf (stderr, "error: skipping config set %d \n", (int) (i + 1));
+            continue;
         }
 
         create_logrotate_config (config);
 
         g_thread_new (NULL, thread_func, config);
     }
+
+    for (size_t i = 0; i < dest_count; i++)
+    {
+        free (destination_array[i]);
+    }
+    free (destination_array);
 
     return 0;
 }

--- a/recorder.c
+++ b/recorder.c
@@ -19,11 +19,9 @@
 #include "apteryx_sync.h"
 
 static const int path_buffer = 256;
-static const int index_buffer = 32;
 static const int json_indent = 2;
 
-static void compare_json_deep(json_t *old_json, json_t *new_json, 
-                               const char *path_prefix, json_t *changes);
+static json_t *compare_json_deep(json_t *old_json, json_t *new_json);
 
 typedef struct _config_data
 {
@@ -41,11 +39,8 @@ json_t *gnode_to_json(const GNode *node)
     json_t *obj = json_object();
     if (!obj) return NULL;
 
-    for (const GNode *child = node->children;
-         child;
-         child = child->next)
+    for (const GNode *child = node->children; child; child = child->next)
     {
-
         json_t *child_json = NULL;
         if (APTERYX_HAS_VALUE(child))
         {
@@ -54,7 +49,8 @@ json_t *gnode_to_json(const GNode *node)
         else
         {
             child_json = gnode_to_json(child);
-            if (!child_json) {
+            if (!child_json)
+            {
                 json_decref(obj);
                 return NULL;
             }
@@ -69,7 +65,8 @@ json_t *gnode_to_json(const GNode *node)
 static int make_path(char *path)
 {
     char *p = path + (*path == '/');  // Skip leading /
-    while ((p = strchr(p, '/'))) {
+    while ((p = strchr(p, '/')))
+    {
         *p = '\0';
         if (mkdir(path, 0755) && errno != EEXIST) return -1;
         *p++ = '/';
@@ -78,105 +75,80 @@ static int make_path(char *path)
 }
 
 
-static void build_path(char *buffer, size_t size, const char *prefix, const char *key)
+static json_t *compare_objects(json_t *old_obj, json_t *new_obj)
 {
-    if (strlen(prefix) == 0)
-    {
-        snprintf(buffer, size, "%s", key);
-    }
-    else
-    {
-        snprintf(buffer, size, "%s.%s", prefix, key);
-    }
-}
-
-static void compare_objects(json_t *old_obj, json_t *new_obj,
-                           const char *path_prefix, json_t *changes)
-{
+    json_t *changes = json_object();
     const char *key;
     json_t *value;
     
     json_object_foreach(old_obj, key, value)
     {
-        char new_path[path_buffer];
-        build_path(new_path, sizeof(new_path), path_prefix, key);        
-        json_t *new_value = json_object_get(new_obj, key);
-        compare_json_deep(value, new_value, new_path, changes);
+        json_t *diff = compare_json_deep(value, json_object_get(new_obj, key));
+        if (diff) json_object_set_new(changes, key, diff);
     }
     
-    // This is needed to find NEW keys (thus causing NULLs in the diff)
     json_object_foreach(new_obj, key, value)
     {
         if (!json_object_get(old_obj, key))
         {
-            char new_path[path_buffer];
-            build_path(new_path, sizeof(new_path), path_prefix, key);
-            json_object_set_new(changes, new_path, json_null());
+            json_object_set_new(changes, key, json_null());
         }
     }
+
+    if (!json_object_size(changes))
+    {
+        json_decref(changes);
+        return NULL;
+    }
+    return changes;
 }
 
-static void compare_arrays(const json_t *old_arr, const json_t *new_arr,
-                          const char *path_prefix, json_t *changes)
+static json_t *compare_arrays(const json_t *old_arr, const json_t *new_arr)
 {
     size_t old_size = json_array_size(old_arr);
     size_t new_size = json_array_size(new_arr);
     size_t max_size = old_size > new_size ? old_size : new_size;
+
+    json_t *changes = json_array();
+    gboolean has_changes = FALSE;
     
     for (size_t i = 0; i < max_size; i++)
-    {
-        char index_str[index_buffer];
-        snprintf(index_str, sizeof(index_str), "%zu", i);
-        
-        char new_path[path_buffer];
-        build_path(new_path, sizeof(new_path), path_prefix, index_str);
-        
+    {       
         json_t *old_elem = i < old_size ? json_array_get(old_arr, i) : json_null();
         json_t *new_elem = i < new_size ? json_array_get(new_arr, i) : json_null();
-        
-        compare_json_deep(old_elem, new_elem, new_path, changes);
+        json_t *diff = compare_json_deep(old_elem, new_elem);
+
+        // Always append to maintain index alignment
+        json_array_append_new(changes, diff ? diff : json_null());
+        if (diff) has_changes = TRUE;
     }
+
+    if (!has_changes)
+    {
+        json_decref(changes);
+        return NULL;
+    }
+    return changes;
 }
 
 // Compares objects based on their type
-static void compare_json_deep(json_t *old_json, json_t *new_json, 
-                               const char *path_prefix, json_t *changes)
+static json_t *compare_json_deep(json_t *old_json, json_t *new_json)
 {
-    if (!old_json && !new_json) return;
-    
-    if (!old_json && new_json)
-    {
-        json_object_set_new(changes, path_prefix, json_null());
-        return;
-    }
-    
-    if (old_json && !new_json)
-    {
-        json_object_set(changes, path_prefix, old_json);
-        return;
-    }
+    if (!old_json && !new_json) return NULL;
+    if (!old_json) return json_null();
+    if (!new_json) return json_incref(old_json);
     
     // Cant easily compare different types
     if (json_typeof(old_json) != json_typeof(new_json))
     {
-        json_object_set(changes, path_prefix, old_json);
-        return;
+        return json_incref(old_json);
     }
     
     switch (json_typeof(old_json))
     {
-        case JSON_OBJECT:
-            compare_objects(old_json, new_json, path_prefix, changes);
-            break;
-        case JSON_ARRAY:
-            compare_arrays(old_json, new_json, path_prefix, changes);
-            break;
-        default: // E.g. string / num / bool
-            if (!json_equal(old_json, new_json))
-            {
-                json_object_set(changes, path_prefix, old_json);
-            }
-            break;
+        case JSON_OBJECT: return compare_objects(old_json, new_json);
+        case JSON_ARRAY: return compare_arrays(old_json, new_json);
+        default: return json_equal(old_json, new_json) ? NULL : json_incref(old_json);
     }
 }
 
@@ -185,18 +157,18 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
     int error_code;
     json_error_t error;
     json_t *storage = json_load_file(path_to_diff, 0, &error);
+    json_t *diff = json_object();
    
     if (!storage)
     {
         json_t *new_storage = json_object();
         json_object_set_new(new_storage, "current", json_deep_copy(current_json));
         
-        json_t *diffs_array = json_array();
-        json_t *initial_diff = json_object();
-        json_object_set_new(initial_diff, "timestamp", json_integer(time(NULL)));
-        json_object_set_new(initial_diff, "changes", json_object());
-        json_array_append_new(diffs_array, initial_diff);
+        json_object_set_new(diff, "timestamp", json_integer(time(NULL)));
+        json_object_set_new(diff, "changes", json_object());
         
+        json_t *diffs_array = json_array();
+        json_array_append_new(diffs_array, diff);
         json_object_set_new(new_storage, "diffs", diffs_array);
         
         error_code = json_dump_file(new_storage, path_to_diff, JSON_INDENT(json_indent));
@@ -205,17 +177,12 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
         return error_code;
     }
     
-    json_t *old_current = json_object_get(storage, "current");
-    json_t *changes = json_object();
-    compare_json_deep(old_current, current_json, "", changes);
+    json_t *changes = compare_json_deep(json_object_get(storage, "current"), current_json);
     
-    json_t *new_diff = json_object();
-    json_object_set_new(new_diff, "timestamp", json_integer(time(NULL)));
-    json_object_set_new(new_diff, "changes", changes);
+    json_object_set_new(diff, "timestamp", json_integer(time(NULL)));
+    json_object_set_new(diff, "changes", changes ? changes : json_object());
     
-    json_t *diffs_array = json_object_get(storage, "diffs");
-    json_array_append_new(diffs_array, new_diff);
-    
+    json_array_append_new(json_object_get(storage, "diffs"), diff);
     json_object_set_new(storage, "current", json_deep_copy(current_json));
     
     error_code = json_dump_file(storage, path_to_diff, JSON_INDENT(json_indent));
@@ -225,16 +192,21 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
 }
 
 
+// Creates a unique name for logrotate conf based on destination
 static char* sanitize_path_for_config(const char *path)
 {
     char *result = malloc(strlen(path) + 7);
     strcpy(result, "config-");
     char *dst = result + 7;
     
-    for (const char *src = path; *src; src++) {
-        if (*src == '/' || *src == '.') {
+    for (const char *src = path; *src; src++)
+    {
+        if (*src == '/' || *src == '.')
+        {
             *dst++ = '-';
-        } else if (isalnum(*src) || *src == '_') {
+        } 
+        else if (isalnum(*src) || *src == '_') 
+        {
             *dst++ = *src;
         }
     }
@@ -249,7 +221,7 @@ static char* resolve_absolute_path(const char *path)
     char *resolved = realpath(path, NULL);
     if (resolved) return resolved;
 
-    // In the likely case there is no file, resolve parent directory instead (& append name)
+    // If there is no file, resolve parent directory instead (& append name)
     char *path_copy = strdup(path);
     char *resolved_dir = realpath(dirname(path_copy), NULL);
     free(path_copy);
@@ -279,7 +251,8 @@ static void create_logrotate_config(config_data *config)
     snprintf(config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
     
     FILE *f = fopen(config_path, "w");
-    if (!f) {
+    if (!f)
+    {
         fprintf(stderr, "error: failed to create logrotate config: %s\n", config_path);
         free(absolute_path);
         free(config_name);
@@ -300,7 +273,8 @@ static void create_logrotate_config(config_data *config)
 }
 
 
-static gboolean polling_callback(gpointer user_data) {
+static gboolean polling_callback(gpointer user_data)
+{
     config_data *config = (config_data *)user_data;
 
     GNode *tree = apteryx_query (g_node_new (config->query));
@@ -308,7 +282,8 @@ static gboolean polling_callback(gpointer user_data) {
     json_t *json_from_tree = tree ? gnode_to_json(tree) : NULL;
     apteryx_free_tree (tree);
 
-    if (!json_from_tree) {
+    if (!json_from_tree)
+    {
         fprintf(stderr, "error: could not fetch JSON from query: %s\n", config->query);
         return G_SOURCE_CONTINUE;
     }
@@ -325,7 +300,8 @@ static gboolean polling_callback(gpointer user_data) {
     return G_SOURCE_CONTINUE;
 }
 
-static gpointer thread_func(gpointer user_data) {
+static gpointer thread_func(gpointer user_data)
+{
     config_data *config = (config_data *)user_data;
     
     GMainContext *context = g_main_context_new();
@@ -442,14 +418,15 @@ int main(int argc, char *argv[])
 
     if(argc != 2)
     {
-        fprintf(stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n\n", argv[0]);
-        fprintf(stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n\n");
+        fprintf(stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n", argv[0]);
+        fprintf(stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n");
         return -1;
     }
 
     root = json_load_file(argv[1], 0, &error);
-    if(!root) {
-        fprintf(stderr, "error: unable to open file.");
+    if(!root)
+    {
+        fprintf(stderr, "error: unable to open file: %s\n", argv[1]);
         return -1;
     }
 

--- a/recorder.c
+++ b/recorder.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <ctype.h>
 #include <pthread.h>
 #include <dirent.h>
 #include <apteryx.h>
@@ -298,6 +299,49 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
 }
 
 
+static char* sanitize_path_for_config(const char *path) {
+    char *result = malloc(strlen(path) + 7);
+    strcpy(result, "config-");
+    char *dst = result + 7;
+    
+    for (const char *src = path; *src; src++) {
+        if (*src == '/' || *src == '.') {
+            *dst++ = '-';
+        } else if (isalnum(*src) || *src == '_') { // Check for exceptions
+            *dst++ = *src;
+        }
+    }
+
+    *dst = '\0';
+    return result;
+}
+
+static void create_logrotate_config(config_data *config) {
+    char *config_name = sanitize_path_for_config(config->destination);
+
+    char config_path[path_buffer];
+    snprintf(config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
+    
+    FILE *f = fopen(config_path, "w");
+    if (!f) {
+        fprintf(stderr, "Failed to create logrotate config: %s\n", config_path);
+        free(config_name);
+        return;
+    }
+    
+    fprintf(f, "%s {\n", config->destination); // Needs to be absolute path...
+    fprintf(f, "    size %ldM\n", config->max_size);
+    fprintf(f, "    rotate %d\n", config->max_samples);
+    fprintf(f, "    missingok\n");
+    fprintf(f, "    notifempty\n");
+    fprintf(f, "    nocreate\n");
+    fprintf(f, "}\n");
+    
+    fclose(f);
+    free(config_name);
+}
+
+
 static gboolean polling_callback(gpointer user_data) {
     config_data *config = (config_data *)user_data;
 
@@ -467,6 +511,8 @@ int main(int argc, char *argv[])
         config->destination = strdup(json_string_value(destination));
         config->max_samples = json_integer_value(max_samples);
         config->max_size = json_integer_value(max_size);
+
+        create_logrotate_config(config);
 
         g_thread_new(NULL, thread_func, config);
     }

--- a/recorder.c
+++ b/recorder.c
@@ -22,6 +22,17 @@ static const int json_indent = 2;
 
 static void compare_json_deep(json_t *old_json, json_t *new_json, 
                                const char *path_prefix, json_t *changes);
+
+typedef struct _config_data
+{
+    char *query;
+    long frequency;
+    char *destination;
+    int max_samples;
+    long max_size;
+    GMainLoop *loop;
+} config_data;
+                       
 // FIXME: Make errors & general style consistent with other ATL/ Apteryx... e.g. error codes...
 
 // FIXME: Replace w/ json_load_file?
@@ -103,23 +114,15 @@ json_t *gnode_to_json(const GNode *node)
     return obj;
 }
 
-static int make_dir(const char *path)
+static int make_path(const char *path)
 {
-    if (mkdir(path, 0600) == -1)
-    {
-        if (errno == EEXIST)
-        {
-            printf("Directory already exists.\n");
-        }
-        else
-        {
-            perror("mkdir failed");
-        }
+    char *p = path + (*path == '/');  // Skip leading /
+    while ((p = strchr(p, '/'))) {
+        *p = '\0';
+        if (mkdir(path, 0755) && errno != EEXIST) return 0;
+        *p++ = '/';
     }
-    else
-    {
-        printf("Directory created successfully.\n");
-    }
+    return 1;
 }
 
 
@@ -161,10 +164,7 @@ static void compare_objects(json_t *old_obj, json_t *new_obj,
     json_object_foreach(old_obj, key, value)
     {
         char new_path[path_buffer];
-        build_path(new_path, sizeof(new_path), path_prefix, key);
-        
-        printf("My KEY is: %s", key);
-        
+        build_path(new_path, sizeof(new_path), path_prefix, key);        
         json_t *new_value = json_object_get(new_obj, key);
         compare_json_deep(value, new_value, new_path, changes);
     }
@@ -255,7 +255,7 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
     {
 
         // attempt to make the path before creating the JSON
-        if(!make_dir(path_to_diff)) return 0;
+        if(!make_path(path_to_diff)) return 0;
 
         json_t *new_storage = json_object();
         json_object_set_new(new_storage, "current", json_deep_copy(current_json));
@@ -295,6 +295,53 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
     if (error_code != 0) return 0;
     
     return 1;
+}
+
+
+static gboolean polling_callback(gpointer user_data) {
+    config_data *config = (config_data *)user_data;
+
+    GNode *tree = apteryx_query (g_node_new (config->query));
+        
+    json_t *json_from_tree = tree ? gnode_to_json(tree) : NULL;
+    apteryx_free_tree (tree);
+
+    if (!json_from_tree) {
+        fprintf(stderr, "error: could not fetch JSON from query: %s\n", config->query);
+        return G_SOURCE_CONTINUE; // Should it terminate the thread/loop?
+    }
+    
+    if (write_diff(json_from_tree, config->destination) != 1)
+    {
+        fprintf(stderr, "error: could not write diff. Check destination: %s\n", config->destination);
+        json_decref(json_from_tree);
+        return G_SOURCE_REMOVE;
+    }    
+    
+    json_decref(json_from_tree);
+    
+    return G_SOURCE_CONTINUE;
+}
+
+static gpointer thread_func(gpointer user_data) {
+    config_data *config = (config_data *)user_data;
+    
+    GMainContext *context = g_main_context_new();
+    config->loop = g_main_loop_new(context, FALSE);
+
+    g_main_context_push_thread_default(context);
+    
+    GSource *timeout = g_timeout_source_new_seconds(config->frequency);
+    g_source_set_callback(timeout, polling_callback, config, NULL);
+    g_source_attach(timeout, context);
+    g_source_unref(timeout);
+    
+    g_main_loop_run(config->loop);
+    
+    g_main_context_pop_thread_default(context);
+    g_main_context_unref(context);
+    
+    return NULL;
 }
 
 
@@ -357,6 +404,8 @@ int main(int argc, char *argv[])
     // FIXME: Put into separate functionS
     for(i = 0; i < json_array_size(root); i++)
     {
+        // TODO: Verify data. e.g. unique dest(?), limits on freq/max values
+        // What to do if an identical query is attempted? Prefer more frequent or older?
         json_t *data, *query, *frequency, *destination, *max_samples, *max_size;
         //  "query": "/test/*/tests",
         // "frequency": "30"(s),
@@ -412,35 +461,20 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        // TODO: Make a new thread for EACH config file: give it relevant config info
-        // FIXME: Put into separate function
-        char *query_text;
-        query_text = strdup(json_string_value(query));
-        
-        printf("s %s  TO %s\n",
-            query_text, 
-            json_string_value(destination)
-            );
+        config_data *config = malloc(sizeof(config_data));
+        config->query = strdup(json_string_value(query));
+        config->frequency = json_integer_value(frequency);
+        config->destination = strdup(json_string_value(destination));
+        config->max_samples = json_integer_value(max_samples);
+        config->max_size = json_integer_value(max_size);
 
-        GNode *gquery = g_node_new (query_text); 
-        GNode *tree = apteryx_query(gquery); // FIXME: Prevent segfaults from bad queries...
-        json_t *json_from_tree = gnode_to_json(tree);
-
-        if (json_from_tree)
-        {
-            if (write_diff(json_from_tree, json_string_value(destination)) != 1)
-            {
-                printf("error: could not complete diff calculation. Check destination.\n");
-                return 0;
-            }
-
-            json_decref(json_from_tree);
-            apteryx_free_tree (tree);
-        } else {
-            printf("error: could not fetch JSON from query. Is it empty?\n");
-        }
+        g_thread_new(NULL, thread_func, config);
     }
 
     json_decref(root);
+
+    GMainLoop *main_loop = g_main_loop_new(NULL, false);
+    g_main_loop_run(main_loop);
+
     return 0;
 }

--- a/recorder.c
+++ b/recorder.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <errno.h>
 #include <time.h>
+#include <libgen.h>
 #include <jansson.h>
 #include "common.h"
 #include "apteryx_sync.h"
@@ -34,56 +35,6 @@ typedef struct _config_data
     GMainLoop *loop;
 } config_data;
                        
-// FIXME: Make errors & general style consistent with other ATL/ Apteryx... e.g. error codes...
-
-// FIXME: Replace w/ json_load_file?
-static char* load_file(const char* filename) {
-    FILE* f = fopen(filename, "r");
-    if (!f) return NULL;
-
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    rewind(f);
-
-    char *buffer = malloc(size + 1);
-    if (buffer)
-    {
-        long bytes_read = fread(buffer, 1, size, f);
-        if (bytes_read < size) return NULL; // File was not completely read...
-        buffer[size] = '\0';
-    }
-    fclose(f);
-    return buffer;
-}
-
-// FIXME: Function decomp
-// static int read_text(char* json_text, json_t* root) {
-//     json_error_t error;
-//     json_t *temp_root;
-
-
-//     temp_root = json_loads(json_text, 0, &error);
-//     free(json_text);
-
-
-//     if(!temp_root)
-//     {
-//         fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
-//         return 0;
-//     }
-
-//     if(!json_is_array(temp_root))
-//     {
-//         fprintf(stderr, "error: root is not an array\n");
-//         json_decref(temp_root);
-//         return 0;
-//     }
-
-//     *root = *temp_root;
-
-//     return 1;
-// }
-
 
 json_t *gnode_to_json(const GNode *node)
 {
@@ -115,21 +66,18 @@ json_t *gnode_to_json(const GNode *node)
     return obj;
 }
 
-static int make_path(const char *path)
+static int make_path(char *path)
 {
     char *p = path + (*path == '/');  // Skip leading /
     while ((p = strchr(p, '/'))) {
         *p = '\0';
-        if (mkdir(path, 0755) && errno != EEXIST) return 0;
+        if (mkdir(path, 0755) && errno != EEXIST) return -1;
         *p++ = '/';
     }
-    return 1;
+    return 0;
 }
 
 
-
-// TODO: Change dot notation to be more like actual tree... 
-// Uses dot notation for children/indices. e.g. parent.child.0
 static void build_path(char *buffer, size_t size, const char *prefix, const char *key)
 {
     if (strlen(prefix) == 0)
@@ -142,20 +90,6 @@ static void build_path(char *buffer, size_t size, const char *prefix, const char
     }
 }
 
-// FIXME(?): json foreach/set discards const....
-    // I assume its better to keep const and suppress warnings...
-
-// FIXME: Optimise option...
-    // void *iter = json_object_iter((json_t*)new_obj);
-    // while (iter) {
-    //     const char *key = json_object_iter_key(iter);
-    //     json_t *old_val = json_object_get(old_obj, key);
-    //     json_t *new_val = json_object_iter_value(iter);
-    //     // compare and mark new keys
-    //     iter = json_object_iter_next((json_t*)new_obj, iter);
-    // }
-    // // Then iterate old_obj only for removed keys
-// Compares JSON objects
 static void compare_objects(json_t *old_obj, json_t *new_obj,
                            const char *path_prefix, json_t *changes)
 {
@@ -254,10 +188,6 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
    
     if (!storage)
     {
-
-        // attempt to make the path before creating the JSON
-        if(!make_path(path_to_diff)) return 0;
-
         json_t *new_storage = json_object();
         json_object_set_new(new_storage, "current", json_deep_copy(current_json));
         
@@ -272,9 +202,7 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
         error_code = json_dump_file(new_storage, path_to_diff, JSON_INDENT(json_indent));
         json_decref(new_storage);
 
-        if (error_code != 0) return 0;
-
-        return 1;
+        return error_code;
     }
     
     json_t *old_current = json_object_get(storage, "current");
@@ -282,7 +210,7 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
     compare_json_deep(old_current, current_json, "", changes);
     
     json_t *new_diff = json_object();
-    json_object_set_new(new_diff, "timestamp", json_integer(time(NULL))); // Should timestamp be earlier?
+    json_object_set_new(new_diff, "timestamp", json_integer(time(NULL)));
     json_object_set_new(new_diff, "changes", changes);
     
     json_t *diffs_array = json_object_get(storage, "diffs");
@@ -292,14 +220,13 @@ static int write_diff(json_t *current_json, const char* path_to_diff)
     
     error_code = json_dump_file(storage, path_to_diff, JSON_INDENT(json_indent));
     json_decref(storage);
-
-    if (error_code != 0) return 0;
     
-    return 1;
+    return error_code;
 }
 
 
-static char* sanitize_path_for_config(const char *path) {
+static char* sanitize_path_for_config(const char *path)
+{
     char *result = malloc(strlen(path) + 7);
     strcpy(result, "config-");
     char *dst = result + 7;
@@ -307,7 +234,7 @@ static char* sanitize_path_for_config(const char *path) {
     for (const char *src = path; *src; src++) {
         if (*src == '/' || *src == '.') {
             *dst++ = '-';
-        } else if (isalnum(*src) || *src == '_') { // Check for exceptions
+        } else if (isalnum(*src) || *src == '_') {
             *dst++ = *src;
         }
     }
@@ -316,20 +243,50 @@ static char* sanitize_path_for_config(const char *path) {
     return result;
 }
 
-static void create_logrotate_config(config_data *config) {
-    char *config_name = sanitize_path_for_config(config->destination);
+static char* resolve_absolute_path(const char *path)
+{
+    // If full path already exists, resolve directly
+    char *resolved = realpath(path, NULL);
+    if (resolved) return resolved;
 
+    // In the likely case there is no file, resolve parent directory instead (& append name)
+    char *path_copy = strdup(path);
+    char *resolved_dir = realpath(dirname(path_copy), NULL);
+    free(path_copy);
+
+    if (!resolved_dir) return NULL;
+
+    path_copy = strdup(path);
+    char *result = malloc(strlen(resolved_dir) + strlen(basename(path_copy)) + 2);
+    sprintf(result, "%s/%s", resolved_dir, basename(path_copy));
+
+    free(path_copy);
+    free(resolved_dir);
+    return result;
+}
+
+static void create_logrotate_config(config_data *config)
+{
+    char *absolute_path = resolve_absolute_path(config->destination);
+    if (!absolute_path)
+    {
+        fprintf(stderr, "error: failed to resolve path: %s\n", config->destination);
+        return;
+    }
+    
+    char *config_name = sanitize_path_for_config(config->destination);
     char config_path[path_buffer];
     snprintf(config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
     
     FILE *f = fopen(config_path, "w");
     if (!f) {
-        fprintf(stderr, "Failed to create logrotate config: %s\n", config_path);
+        fprintf(stderr, "error: failed to create logrotate config: %s\n", config_path);
+        free(absolute_path);
         free(config_name);
         return;
     }
     
-    fprintf(f, "%s {\n", config->destination); // Needs to be absolute path...
+    fprintf(f, "%s {\n", absolute_path);
     fprintf(f, "    size %ldM\n", config->max_size);
     fprintf(f, "    rotate %d\n", config->max_samples);
     fprintf(f, "    missingok\n");
@@ -338,6 +295,7 @@ static void create_logrotate_config(config_data *config) {
     fprintf(f, "}\n");
     
     fclose(f);
+    free(absolute_path);
     free(config_name);
 }
 
@@ -352,10 +310,10 @@ static gboolean polling_callback(gpointer user_data) {
 
     if (!json_from_tree) {
         fprintf(stderr, "error: could not fetch JSON from query: %s\n", config->query);
-        return G_SOURCE_CONTINUE; // Should it terminate the thread/loop?
+        return G_SOURCE_CONTINUE;
     }
     
-    if (write_diff(json_from_tree, config->destination) != 1)
+    if (write_diff(json_from_tree, config->destination) != 0)
     {
         fprintf(stderr, "error: could not write diff. Check destination: %s\n", config->destination);
         json_decref(json_from_tree);
@@ -389,63 +347,10 @@ static gpointer thread_func(gpointer user_data) {
 }
 
 
-
-int main(int argc, char *argv[])
+static int initialise_configs(json_t *root)
 {
-    apteryx_init(false);
-
     size_t i;
-    char *text;
-    json_t *root = NULL;
 
-    if(argc != 1)
-    {
-        fprintf(stderr, "usage: %s USER REPOSITORY\n\n", argv[0]);
-        fprintf(stderr, "List commits at USER's REPOSITORY.\n\n");
-        return -1;
-    }
-
-    text = load_file("test.json");
-    if(!text) {
-        fprintf(stderr, "error: unable to open file.");
-        return 0;
-    }
-
-
-    // FIXME: Put into separate function
-    json_error_t error;
-
-    root = json_loads(text, 0, &error);
-    free(text);
-
-    if(!root)
-    {
-        fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
-        return 0;
-    }
-
-    if(!json_is_array(root))
-    {
-        fprintf(stderr, "error: root is not an array\n");
-        json_decref(root);
-        return 0;
-    }
-
-    // if (!read_text(text, root)) {
-    //     fprintf(stderr, "Error: unable to read file as JSON.");
-    //     return 0;
-    // }
-
-    if(!root){
-        fprintf(stderr, "Erdfdfror: unable to read file as JSON.");
-        return 0;
-    }
-
-    
-  
-
-
-    // FIXME: Put into separate functionS
     for(i = 0; i < json_array_size(root); i++)
     {
         // TODO: Verify data. e.g. unique dest(?), limits on freq/max values
@@ -462,7 +367,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d is not an object\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         query = json_object_get(data, "query");
@@ -470,7 +375,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d: query is not a string\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         frequency = json_object_get(data, "frequency");
@@ -478,7 +383,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d: frequency is not an integer\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         destination = json_object_get(data, "destination");
@@ -486,7 +391,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d: destination is not a string\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         max_samples = json_object_get(data, "max_samples");
@@ -494,7 +399,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d: max_samples is not an integer\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         max_size = json_object_get(data, "max_size");
@@ -502,7 +407,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "error: config set %d: max_size is not an integer\n", (int)(i + 1));
             json_decref(root);
-            return 1;
+            return -1;
         }
 
         config_data *config = malloc(sizeof(config_data));
@@ -512,11 +417,50 @@ int main(int argc, char *argv[])
         config->max_samples = json_integer_value(max_samples);
         config->max_size = json_integer_value(max_size);
 
+        // attempt to make destination path before calling logrotate
+        if(make_path(config->destination) != 0)
+        {
+            fprintf(stderr, "error: failed to create specified path: %s\n", config->destination);
+            return -1;
+        }
+
         create_logrotate_config(config);
 
         g_thread_new(NULL, thread_func, config);
     }
 
+    return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+    apteryx_init(false);
+
+    json_t *root;
+    json_error_t error;
+
+    if(argc != 2)
+    {
+        fprintf(stderr, "usage: %s [PATH/TO/CONFIG.JSON]\n\n", argv[0]);
+        fprintf(stderr, "Reads config array from PATH/TO/CONFIG.JSON.\n\n");
+        return -1;
+    }
+
+    root = json_load_file(argv[1], 0, &error);
+    if(!root) {
+        fprintf(stderr, "error: unable to open file.");
+        return -1;
+    }
+
+    if(!json_is_array(root))
+    {
+        fprintf(stderr, "error: config is not an array\n");
+        json_decref(root);
+        return -1;
+    }
+
+    initialise_configs(root);
     json_decref(root);
 
     GMainLoop *main_loop = g_main_loop_new(NULL, false);

--- a/recorder.c
+++ b/recorder.c
@@ -13,14 +13,16 @@
 #include <jansson.h>
 #include <ftw.h>
 #include <unistd.h>
+#include <signal.h>
 #include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
 
 static const int json_indent = 2;
 
-/* Override used for testing. NULL means use default */
+/* Overrides the default logrotate output directory. Set via -l or in tests. NULL means use default */
 static const char *logrotate_dir_override = NULL;
-#define LOGROTATE_DIR_DEFAULT "/etc/logrotate.d"
+#define LOGROTATE_DIR_DEFAULT "/etc/logrotate-conf.d"
+#define LOGROTATE_INCLUDE_FILE "/etc/logrotate.d/recorder"
 
 static json_t *compare_json_deep (json_t *old_json, json_t *new_json);
 
@@ -31,9 +33,18 @@ typedef struct _config_data
     char *destination;
     int max_samples;
     long max_size;
+
+    guint initial_delay;
     GMainLoop *loop;
+    GMainContext *context;
+    GThread *thread;
+    GMutex mutex;
+    GCond cond;
+    gboolean thread_ready;
 } config_data;
 
+static GHashTable *destination_registry = NULL;
+static GPtrArray *active_configs = NULL;
 
 /* Used to convert apteryx result into regular JSON */
 json_t *
@@ -236,6 +247,27 @@ resolve_absolute_path (const char *path)
     return result;
 }
 
+/* Writes a single include directive, allowing logrotate to read from our logrotate config directory */
+static int
+create_logrotate_include (void)
+{
+    const char *out_dir = logrotate_dir_override ? logrotate_dir_override
+        : LOGROTATE_DIR_DEFAULT;
+
+    FILE *f = fopen (LOGROTATE_INCLUDE_FILE, "w");
+    if (!f)
+    {
+        fprintf (stderr, "warning: failed to create logrotate include file %s: %s\n"
+                 "         logrotate will not pick up recorder configs automatically\n",
+                 LOGROTATE_INCLUDE_FILE, strerror (errno));
+        return -1;
+    }
+
+    fprintf (f, "include %s\n", out_dir);
+    fclose (f);
+    return 0;
+}
+
 /* Makes a logrotate config based on user-specified settings */
 static int
 create_logrotate_config (config_data *config)
@@ -252,16 +284,19 @@ create_logrotate_config (config_data *config)
         : LOGROTATE_DIR_DEFAULT;
 
     int n = snprintf (NULL, 0, "%s/%s", out_dir, config_name);
-    if (n < 0)
+    char *config_path = malloc (n + 1);
+    snprintf (config_path, n + 1, "%s/%s", out_dir, config_name);
+    
+    char *directory_to_write = strdup (config_path);
+    if (make_path (directory_to_write) != 0)
     {
         fprintf (stderr, "error: failed to build logrotate config path\n");
         free (absolute_path);
         free (config_name);
+        free (directory_to_write);
         return -1;
     }
-
-    char *config_path = malloc (n + 1);
-    snprintf (config_path, n + 1, "%s/%s", out_dir, config_name);
+    free (directory_to_write);
 
     FILE *f = fopen (config_path, "w");
     if (!f)
@@ -274,7 +309,7 @@ create_logrotate_config (config_data *config)
     }
 
     fprintf (f, "%s {\n"
-             "    size %ldM\n"
+             "    size %ldk\n"
              "    rotate %d\n"
              "    missingok\n"
              "    notifempty\n"
@@ -321,53 +356,241 @@ polling_callback (gpointer user_data)
     return G_SOURCE_CONTINUE;
 }
 
+/* Helper to schedule a callback based on a delay */
+static void
+schedule_periodic_polling (config_data *config, GMainContext *context,
+                           GSourceFunc callback_function, long delay)
+{
+    GSource *timeout = g_timeout_source_new_seconds (delay);
+    g_source_set_callback (timeout, callback_function, config, NULL);
+    g_source_attach (timeout, context);
+    g_source_unref (timeout);
+}
+
+/* Used when a thread is interrupted and has to wait for a non-standard length */
+static gboolean
+initial_polling_callback (gpointer user_data)
+{
+    config_data *config = (config_data *) user_data;
+
+    if (polling_callback (config) == G_SOURCE_CONTINUE)
+    {
+        schedule_periodic_polling (config, g_main_context_get_thread_default (),
+                                   polling_callback, config->frequency);
+    }
+
+    return G_SOURCE_REMOVE;
+}
+
+/* Calculates the remaining delay for an interrupted thread */
+static guint
+calculate_initial_delay_at (long frequency, time_t last_poll_timestamp, time_t now)
+{
+    // If there is no record, or it is somehow in the future, just wait the full frequency
+    if (last_poll_timestamp == 0 || now < last_poll_timestamp)
+    {
+        return (guint) frequency;
+    }
+
+    time_t elapsed = now - last_poll_timestamp;
+    if (elapsed >= frequency)
+    {
+        return 0;
+    }
+
+    return (guint) (frequency - elapsed);
+}
+
+/* Determines when the last poll was */
+static time_t
+read_last_poll_timestamp (const char *path_to_diff)
+{
+    json_error_t error;
+    json_t *storage = json_load_file (path_to_diff, 0, &error);
+    if (!storage)
+    {
+        return 0;
+    }
+
+    json_t *timestamp = json_object_get (storage, "timestamp");
+    time_t result = json_is_integer (timestamp) ?
+        (time_t) json_integer_value (timestamp) : 0;
+
+    json_decref (storage);
+    return result;
+}
+
 /* Setup for the GLib thread */
+static gboolean
+quit_loop_cb (gpointer user_data)
+{
+    g_main_loop_quit ((GMainLoop *) user_data);
+    return G_SOURCE_REMOVE;
+}
+
+/* Controls the setup and teardown of its config alongside poll rebooting */
 static gpointer
 thread_func (gpointer user_data)
 {
     config_data *config = (config_data *) user_data;
 
     GMainContext *context = g_main_context_new ();
-    config->loop = g_main_loop_new (context, FALSE);
+    GMainLoop *loop = g_main_loop_new (context, FALSE);
+
+    g_mutex_lock (&config->mutex);
+    config->context = context;
+    config->loop = loop;
+    config->thread_ready = TRUE;
+    g_cond_signal (&config->cond);
+    g_mutex_unlock (&config->mutex);
 
     g_main_context_push_thread_default (context);
 
-    GSource *timeout = g_timeout_source_new_seconds (config->frequency);
-    g_source_set_callback (timeout, polling_callback, config, NULL);
-    g_source_attach (timeout, context);
-    g_source_unref (timeout);
-
-    g_main_loop_run (config->loop);
+    schedule_periodic_polling (config, context, initial_polling_callback,
+                               config->initial_delay);
+    g_main_loop_run (loop);
 
     g_main_context_pop_thread_default (context);
-    g_main_context_unref (context);
 
+    g_mutex_lock (&config->mutex);
+    config->loop = NULL;
+    config->context = NULL;
+    config->thread_ready = FALSE;
+    g_mutex_unlock (&config->mutex);
+
+    g_main_loop_unref (loop);
+    g_main_context_unref (context);
     return NULL;
 }
 
-/* Ensures there are no configs writing to the same place. Uses destination, config-file pairs*/
-static GHashTable *destination_registry = NULL;
+/* Frees data on error */
+static void
+config_data_free (config_data *config)
+{
+    if (config)
+    {
+        free (config->query);
+        free (config->destination);
+        g_mutex_clear (&config->mutex);
+        g_cond_clear (&config->cond);
+        free (config);
+    }
+}
 
+/* Frees provided objects (either local or global) */
+static void
+free_config_set (GHashTable *registry, GPtrArray *configs)
+{
+    if (configs)
+    {
+        g_ptr_array_free (configs, TRUE);
+    }
+    if (registry)
+    {
+        g_hash_table_destroy (registry);
+    }
+}
+
+/* Controls the teardown of an entire thread  */
+static void
+stop_config_thread (config_data *config)
+{
+    if (!config || !config->thread)
+    {
+        return;
+    }
+
+    g_mutex_lock (&config->mutex);
+
+    /* Wait for thread startup to publish context/loop */
+    while (!config->thread_ready)
+    {
+        g_cond_wait (&config->cond, &config->mutex);
+    }
+
+    GMainContext *context = config->context ? g_main_context_ref (config->context) : NULL;
+    GMainLoop *loop = config->loop ? g_main_loop_ref (config->loop) : NULL;
+    g_mutex_unlock (&config->mutex);
+
+    if (context && loop)
+    {
+        g_main_context_invoke_full (context,
+                                    G_PRIORITY_DEFAULT,
+                                    quit_loop_cb, loop, (GDestroyNotify) g_main_loop_unref);
+    }
+    else if (loop)
+    {
+        g_main_loop_quit (loop);
+        g_main_loop_unref (loop);
+    }
+
+    if (context)
+    {
+        g_main_context_unref (context);
+    }
+
+    g_thread_join (config->thread); // Wait for thread to finish and clean itself up
+    config->thread = NULL;
+}
+
+/* Iterates through configs and stops them */
+static void
+stop_config_set (GPtrArray *configs)
+{
+    if (!configs)
+    {
+        return;
+    }
+
+    for (guint i = 0; i < configs->len; i++)
+    {
+        stop_config_thread (g_ptr_array_index (configs, i));
+    }
+}
+
+/* Iterates through configs and starts them */
+static int
+start_config_set (GPtrArray *configs)
+{
+    if (!configs)
+    {
+        return 0;
+    }
+
+    for (guint i = 0; i < configs->len; i++)
+    {
+        config_data *config = g_ptr_array_index (configs, i);
+
+        config->thread = g_thread_new (NULL, thread_func, config);
+        if (!config->thread)
+        {
+            fprintf (stderr, "error: failed to start config thread for %s\n",
+                     config->destination);
+            stop_config_set (configs);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/* Frees global variables */
 static void
 destination_registry_free_all ()
 {
-    if (destination_registry)
-    {
-        g_hash_table_destroy (destination_registry);
-        destination_registry = NULL;
-    }
+    free_config_set (destination_registry, active_configs);
+    destination_registry = NULL;
+    active_configs = NULL;
 }
 
 /* Adds destination to table. Throws error if it is already present */
 static int
-destination_registry_add (const char *destination, const char *config_path)
+destination_registry_add (GHashTable *registry,
+                          const char *destination, const char *config_path)
 {
-    destination_registry = destination_registry ? destination_registry :
-        g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-
     gchar *key = resolve_absolute_path (destination);
 
-    const char *first_seen = g_hash_table_lookup (destination_registry, key);
+    const char *first_seen = g_hash_table_lookup (registry, key);
     if (first_seen)
     {
         fprintf (stderr,
@@ -378,14 +601,14 @@ destination_registry_add (const char *destination, const char *config_path)
         return -1;
     }
 
-    g_hash_table_insert (destination_registry, key,
-                         g_strdup (config_path ? config_path : "(unknown)"));
+    g_hash_table_insert (registry, key, g_strdup (config_path ? config_path : "(unknown)"));
     return 0;
 }
 
 /* Ensures destination can be created, and has not already been claimed */
 static int
-validate_destination (const char *destination_path, const char *config_path)
+validate_destination (GHashTable *registry,
+                      const char *destination_path, const char *config_path)
 {
     if (!destination_path || !*destination_path)
     {
@@ -404,7 +627,7 @@ validate_destination (const char *destination_path, const char *config_path)
     }
     free (dest_str);
 
-    if (destination_registry_add (destination_path, config_path) != 0)
+    if (destination_registry_add (registry, destination_path, config_path) != 0)
     {
         return -1;
     }
@@ -414,7 +637,8 @@ validate_destination (const char *destination_path, const char *config_path)
 
 /* Validates the data provided in the config file. Mostly checks types */
 static int
-validate_data (json_t *data, config_data *config, const char *config_path)
+validate_and_set_data (json_t *data,
+               config_data *config, GHashTable *registry, const char *config_path)
 {
     json_t *query, *frequency, *destination, *max_samples, *max_size;
 
@@ -431,6 +655,11 @@ validate_data (json_t *data, config_data *config, const char *config_path)
         fprintf (stderr, "error: frequency is not an integer\n");
         return -1;
     }
+    if (json_integer_value (frequency) <= 0)
+    {
+        fprintf (stderr, "error: frequency must be greater than 0\n");
+        return -1;
+    }
 
     destination = json_object_get (data, "destination");
     if (!json_is_string (destination))
@@ -439,7 +668,7 @@ validate_data (json_t *data, config_data *config, const char *config_path)
         return -1;
     }
 
-    if (validate_destination (json_string_value (destination), config_path) != 0)
+    if (validate_destination (registry, json_string_value (destination), config_path) != 0)
     {
         return -1;
     }
@@ -450,6 +679,11 @@ validate_data (json_t *data, config_data *config, const char *config_path)
         fprintf (stderr, "error: max_samples is not an integer\n");
         return -1;
     }
+    if (json_integer_value (max_samples) <= 0)
+    {
+        fprintf (stderr, "error: max_samples must be greater than 0\n");
+        return -1;
+    }
 
     max_size = json_object_get (data, "max_size");
     if (!json_is_integer (max_size))
@@ -457,6 +691,13 @@ validate_data (json_t *data, config_data *config, const char *config_path)
         fprintf (stderr, "error: max_size is not an integer\n");
         return -1;
     }
+    if (json_integer_value (max_size) <= 0)
+    {
+        fprintf (stderr, "error: max_size must be greater than 0\n");
+        return -1;
+    }
+
+
 
     config->query = strdup (json_string_value (query));
     config->frequency = json_integer_value (frequency);
@@ -469,7 +710,8 @@ validate_data (json_t *data, config_data *config, const char *config_path)
 
 /* Tries to setup thread from config file object */
 static int
-initialise_config (json_t *data, const char *config_path)
+initialise_config (json_t *data,
+                   const char *config_path, GHashTable *registry, GPtrArray *configs)
 {
     if (!json_is_object (data))
     {
@@ -477,12 +719,15 @@ initialise_config (json_t *data, const char *config_path)
         return -1;
     }
 
-    config_data *config = malloc (sizeof (config_data));
-    int validation = validate_data (data, config, config_path);
+    config_data *config = calloc (1, sizeof (config_data));
+    g_mutex_init (&config->mutex);
+    g_cond_init (&config->cond);
+
+    int validation = validate_and_set_data (data, config, registry, config_path);
     if (validation != 0)
     {
         fprintf (stderr, "error: bad value in config \n");
-        free (config);
+        config_data_free (config);
         return -1;
     }
 
@@ -490,23 +735,29 @@ initialise_config (json_t *data, const char *config_path)
     if (validation != 0)
     {
         fprintf (stderr, "error: could not start logrotate \n");
-        free (config);
+        config_data_free (config);
         return -1;
     }
 
-    g_thread_new (NULL, thread_func, config);
+    config->initial_delay = calculate_initial_delay_at (config->frequency,
+                                                        read_last_poll_timestamp
+                                                        (config->destination), time (NULL));
+
+    g_ptr_array_add (configs, config);
 
     return 0;
 }
 
-/* Gets all JSON files from specified directory and tries to read them */
+/* Gets all JSON files from specified directory and tries to write data to configs */
 static int
-load_configs_from_directory (const char *config_dir)
+load_configs_from_directory (const char *config_dir,
+                             GHashTable *registry, GPtrArray *configs)
 {
     DIR *dir;
     struct dirent *entry;
     char *ext;
-    char *path;
+    char *path_to_file;
+    char *absolute_config_dir;
     json_t *root;
     json_error_t error;
 
@@ -516,6 +767,8 @@ load_configs_from_directory (const char *config_dir)
         fprintf (stderr, "error: failed to open config directory: %s\n", config_dir);
         return -1;
     }
+
+    absolute_config_dir = resolve_absolute_path (config_dir);
 
     while ((entry = readdir (dir)) != NULL)
     {
@@ -530,32 +783,104 @@ load_configs_from_directory (const char *config_dir)
         {
             continue;
         }
-        path = g_strdup_printf ("%s/%s", config_dir, entry->d_name);
+        path_to_file = g_strdup_printf ("%s/%s", absolute_config_dir, entry->d_name);
 
-        root = json_load_file (path, 0, &error);
+        root = json_load_file (path_to_file, 0, &error);
         if (!root)
         {
-            fprintf (stderr, "error: unable to open file: %s\n", path);
-            g_free (path);
+            fprintf (stderr, "error: unable to open file: %s. May be empty or have too many objects\n", path_to_file);
+            free (absolute_config_dir);
+            g_free (path_to_file);
             closedir (dir);
             return -1;
         }
 
-        if (initialise_config (root, path) != 0)
+        if (initialise_config (root, path_to_file, registry, configs) != 0)
         {
-            fprintf (stderr, "error: failed to initialise config from file: %s\n", path);
+            fprintf (stderr, "error: failed to initialise config from file: %s\n", path_to_file);
+            free (absolute_config_dir);
+            g_free (path_to_file);
             json_decref (root);
-            g_free (path);
             closedir (dir);
             return -1;
         }
 
         json_decref (root);
-        g_free (path);
+        g_free (path_to_file);
     }
 
+    free (absolute_config_dir);
     closedir (dir);
+
+    if (configs->len == 0)
+    {
+        fprintf (stderr, "error: no valid .json config files found in directory: %s\n", config_dir);
+        return -1;
+    }
     return 0;
+}
+
+/* Fills local objects with data from config directory */
+static int
+load_config_set (const char *config_dir, GHashTable **registry, GPtrArray **configs)
+{
+    GHashTable *new_registry = g_hash_table_new_full (g_str_hash,
+                                                      g_str_equal,
+                                                      g_free,
+                                                      g_free);
+    GPtrArray *new_configs = g_ptr_array_new_with_free_func ((GDestroyNotify)
+                                                             config_data_free);
+
+    if (load_configs_from_directory (config_dir, new_registry, new_configs) != 0)
+    {
+        free_config_set (new_registry, new_configs);
+        return -1;
+    }
+
+    *registry = new_registry;
+    *configs = new_configs;
+    return 0;
+}
+
+/* Resets all threads, closing old ones and adding new ones as per config directory info */
+static int
+replace_active_configs (const char *config_dir)
+{
+    GHashTable *new_registry = NULL;
+    GPtrArray *new_configs = NULL;
+
+    if (load_config_set (config_dir, &new_registry, &new_configs) != 0)
+    {
+        return -1;
+    }
+
+    stop_config_set (active_configs);
+    destination_registry_free_all ();
+
+    if (start_config_set (new_configs) != 0)
+    {
+        free_config_set (new_registry, new_configs);
+        return -1;
+    }
+
+    destination_registry = new_registry;
+    active_configs = new_configs;
+
+    return 0;
+}
+
+/* Runs on SIGHUP. Attempts to reload from current config directory */
+static gboolean
+reload_handler (gpointer user_data)
+{
+    const char *config_dir = (const char *) user_data;
+
+    if (replace_active_configs (config_dir) != 0)
+    {
+        fprintf (stderr, "error: failed to reload configs from %s\n", config_dir); // Keeps running with old configs if reload fails
+    }
+
+    return G_SOURCE_CONTINUE;
 }
 
 
@@ -787,6 +1112,90 @@ test_compare_json_deep_removed_key_returns_old_value ()
     json_decref (result);
 }
 
+void
+test_calculate_initial_delay_at_missing_timestamp_returns_frequency ()
+{
+    CU_ASSERT_EQUAL (calculate_initial_delay_at (30, 0, 100), 30);
+}
+
+void
+test_calculate_initial_delay_at_future_timestamp_returns_frequency ()
+{
+    CU_ASSERT_EQUAL (calculate_initial_delay_at (30, 200, 100), 30);
+}
+
+void
+test_calculate_initial_delay_at_overdue_returns_immediate ()
+{
+    CU_ASSERT_EQUAL (calculate_initial_delay_at (30, 60, 100), 0);
+}
+
+void
+test_calculate_initial_delay_at_partial_interval_returns_remaining ()
+{
+    CU_ASSERT_EQUAL (calculate_initial_delay_at (30, 80, 100), 10);
+}
+
+void
+test_read_last_poll_timestamp_missing_file_returns_zero ()
+{
+    time_t result = read_last_poll_timestamp ("");
+    CU_ASSERT_EQUAL (result, 0);
+}
+
+static int
+write_test_timestamp_file (const char *path_to_diff, json_t *timestamp)
+{
+    json_t *root = json_object ();
+
+    if (timestamp)
+    {
+        json_object_set (root, "timestamp", timestamp);
+    }
+
+    int rc = json_dump_file (root, path_to_diff, 0);
+    json_decref (root);
+    return rc;
+}
+
+void
+test_read_last_poll_timestamp_valid_file_returns_value ()
+{
+    char path[] = "/tmp/recorder_timestamp_valid_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+
+    json_t *timestamp = json_integer (1234);
+
+    CU_ASSERT_EQUAL_FATAL (write_test_timestamp_file (path, timestamp), 0);
+
+    time_t result = read_last_poll_timestamp (path);
+    CU_ASSERT_EQUAL (result, 1234);
+
+    unlink (path);
+    json_decref (timestamp);
+}
+
+void
+test_read_last_poll_timestamp_non_integer_returns_zero ()
+{
+    char path[] = "/tmp/recorder_timestamp_nonint_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+
+    json_t *timestamp = json_string ("bad");
+
+    CU_ASSERT_EQUAL_FATAL (write_test_timestamp_file (path, timestamp), 0);
+
+    time_t result = read_last_poll_timestamp (path);
+    CU_ASSERT_EQUAL (result, 0);
+
+    unlink (path);
+    json_decref (timestamp);
+}
+
 
 int
 main (int argc, char *argv[])
@@ -797,7 +1206,7 @@ main (int argc, char *argv[])
     CU_pSuite pSuite;
     GMainLoop *main_loop = NULL;
 
-    while ((opt = getopt (argc, argv, "huc:")) != -1)
+    while ((opt = getopt (argc, argv, "huc:l::")) != -1)
     {
         switch (opt)
         {
@@ -807,13 +1216,18 @@ main (int argc, char *argv[])
         case 'c':
             config_dir = optarg;
             break;
+        case 'l':
+            logrotate_dir_override = optarg;
+            break;
         case '?':
         case 'h':
         default:
-            printf ("Usage: %s [-h] [-u] [-c <configdir>]\n"
+            printf ("Usage: %s [-h] [-u] [-c <configdir>] [-l <logrotate_dir>]\n"
                     "  -h   show this help\n"
                     "  -u   run unit tests\n"
-                    "  -c   use files from <configdir>\n", argv[0]);
+                    "  -c   use files from <configdir>\n"
+                    "  -l   write logrotate configs to <logrotate_dir> (default: %s)\n",
+                    argv[0], LOGROTATE_DIR_DEFAULT);
             return 0;
         }
     }
@@ -857,6 +1271,22 @@ main (int argc, char *argv[])
         CU_add_test (pSuite, "removed_key_returns_old_value",
                      test_compare_json_deep_removed_key_returns_old_value);
 
+        pSuite = CU_add_suite ("unit::reload_timing", NULL, NULL);
+        CU_add_test (pSuite, "missing_timestamp_returns_frequency",
+                     test_calculate_initial_delay_at_missing_timestamp_returns_frequency);
+        CU_add_test (pSuite, "future_timestamp_returns_frequency",
+                     test_calculate_initial_delay_at_future_timestamp_returns_frequency);
+        CU_add_test (pSuite, "overdue_returns_immediate",
+                     test_calculate_initial_delay_at_overdue_returns_immediate);
+        CU_add_test (pSuite, "partial_interval_returns_remaining",
+                     test_calculate_initial_delay_at_partial_interval_returns_remaining);
+        CU_add_test (pSuite, "missing_file_returns_zero",
+                     test_read_last_poll_timestamp_missing_file_returns_zero);
+        CU_add_test (pSuite, "valid_file_returns_value",
+                     test_read_last_poll_timestamp_valid_file_returns_value);
+        CU_add_test (pSuite, "non_integer_returns_zero",
+                     test_read_last_poll_timestamp_non_integer_returns_zero);
+
         CU_basic_set_mode (CU_BRM_VERBOSE);
         CU_basic_run_tests ();
         int failures = CU_get_number_of_failures ();
@@ -875,12 +1305,17 @@ main (int argc, char *argv[])
 
     apteryx_init (false);
 
-    if (load_configs_from_directory (config_dir) != 0)
+    create_logrotate_include ();
+
+    if (replace_active_configs (config_dir) != 0)
     {
         goto exit;
     }
 
     main_loop = g_main_loop_new (NULL, false);
+    g_unix_signal_add (SIGINT, quit_loop_cb, main_loop);
+    g_unix_signal_add (SIGTERM, quit_loop_cb, main_loop);
+    g_unix_signal_add (SIGHUP, reload_handler, (gpointer) config_dir);
     g_main_loop_run (main_loop);
 
 
@@ -889,6 +1324,9 @@ main (int argc, char *argv[])
     {
         g_main_loop_unref (main_loop);
     }
+
+    /* Stop all running config threads before freeing their data */
+    stop_config_set (active_configs);
 
     /* Cleanup destination registry */
     destination_registry_free_all ();

--- a/recorder.c
+++ b/recorder.c
@@ -475,13 +475,23 @@ load_configs_from_directory (const char *config_dir)
 void
 test_compare_json_deep_nulls ()
 {
-    CU_ASSERT_PTR_NULL (compare_json_deep (NULL, NULL));
+    json_t *old = NULL;
+    json_t *new = NULL;
+    json_t *result = NULL;
+    CU_ASSERT_PTR_NULL (compare_json_deep (old, new));
     
-    CU_ASSERT_EQUAL (compare_json_deep (NULL, json_object ()), json_null ());
+    new = json_object ();
+    result = json_null ();
+    CU_ASSERT_EQUAL (compare_json_deep (old, new), result);
+    json_decref (new);
+    json_decref (result);
 
-    json_t *old = json_object ();
-    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, NULL), old);
+    old = json_object ();
+    new = NULL;
+    result = old;
+    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, NULL), result);
     json_decref (old);
+    json_decref (result);
 }
 
 void
@@ -489,11 +499,13 @@ test_compare_json_deep_different_types ()
 {
     json_t *old = json_object ();
     json_t *new = json_string ("new value");
+    json_t *result = old;
 
-    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, new), old);
+    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, new), result);
 
     json_decref (old);
     json_decref (new);
+    json_decref (result);
 }
 
 

--- a/recorder.c
+++ b/recorder.c
@@ -11,11 +11,16 @@
 #include <dirent.h>
 #include <libgen.h>
 #include <jansson.h>
+#include <ftw.h>
+#include <unistd.h>
 #include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
 
-static const int path_buffer = 256;
 static const int json_indent = 2;
+
+/* Override used for testing. NULL means use default */
+static const char *logrotate_dir_override = NULL;
+#define LOGROTATE_DIR_DEFAULT "/etc/logrotate.d"
 
 static json_t *compare_json_deep (json_t *old_json, json_t *new_json);
 
@@ -30,6 +35,7 @@ typedef struct _config_data
 } config_data;
 
 
+/* Used to convert apteryx result into regular JSON */
 json_t *
 gnode_to_json (const GNode *node)
 {
@@ -62,6 +68,7 @@ gnode_to_json (const GNode *node)
     return obj;
 }
 
+/* Generates destination directories if needed */
 static int
 make_path (char *path)
 {
@@ -79,6 +86,7 @@ make_path (char *path)
 }
 
 
+/* Compares JSON objects by comparing their individual values */
 static json_t *
 compare_objects (json_t *old_obj, json_t *new_obj)
 {
@@ -111,6 +119,7 @@ compare_objects (json_t *old_obj, json_t *new_obj)
     return changes;
 }
 
+/* Tries to compare primitively, otherwise defers to compare_objects for recursion */
 static json_t *
 compare_json_deep (json_t *old_json, json_t *new_json)
 {
@@ -136,13 +145,13 @@ compare_json_deep (json_t *old_json, json_t *new_json)
     return compare_objects (old_json, new_json);
 }
 
+/* Creates, or edits, the JSON diff file */
 static int
 write_diff (json_t *current_json, const char *path_to_diff)
 {
     int error_code;
     json_error_t error;
     json_t *storage = json_load_file (path_to_diff, 0, &error);
-    json_t *diff = json_object ();
 
     if (!storage)
     {
@@ -161,6 +170,7 @@ write_diff (json_t *current_json, const char *path_to_diff)
 
     json_t *changes =
         compare_json_deep (json_object_get (storage, "current"), current_json);
+    json_t *diff = json_object ();
 
     json_object_set_new (diff, "timestamp",
                          json_deep_copy (json_object_get (storage, "timestamp")));
@@ -177,11 +187,11 @@ write_diff (json_t *current_json, const char *path_to_diff)
 }
 
 
-// Creates a unique name for logrotate conf based on destination
+/* Creates a unique name for logrotate config file based on specified diff destination */
 static char *
 sanitize_path_for_config (const char *path)
 {
-    char *result = malloc (strlen (path) + 7);
+    char *result = malloc (strlen (path) + 8);
     strcpy (result, "config-");
     char *dst = result + 7;
 
@@ -201,25 +211,21 @@ sanitize_path_for_config (const char *path)
     return result;
 }
 
+/* Turns a relative path into absolute for consistent comparison */
 static char *
 resolve_absolute_path (const char *path)
 {
-    // If full path already exists, resolve directly
+    /* Path should always exist, as it will crash earlier if not. File might not */
     char *resolved = realpath (path, NULL);
     if (resolved)
     {
         return resolved;
     }
 
-    // If there is no file, resolve parent directory instead (& append name)
+    /* If there is no file, resolve parent directory, then append name */
     char *path_copy = strdup (path);
     char *resolved_dir = realpath (dirname (path_copy), NULL);
     free (path_copy);
-
-    if (!resolved_dir)
-    {
-        return NULL;
-    }
 
     path_copy = strdup (path);
     char *result = malloc (strlen (resolved_dir) + strlen (basename (path_copy)) + 2);
@@ -230,19 +236,32 @@ resolve_absolute_path (const char *path)
     return result;
 }
 
-static void
+/* Makes a logrotate config based on user-specified settings */
+static int
 create_logrotate_config (config_data *config)
 {
     char *absolute_path = resolve_absolute_path (config->destination);
     if (!absolute_path)
     {
         fprintf (stderr, "error: failed to resolve path: %s\n", config->destination);
-        return;
+        return -1;
     }
 
     char *config_name = sanitize_path_for_config (config->destination);
-    char config_path[path_buffer];
-    snprintf (config_path, path_buffer, "/etc/logrotate.d/%s", config_name);
+    const char *out_dir = logrotate_dir_override ? logrotate_dir_override
+        : LOGROTATE_DIR_DEFAULT;
+
+    int n = snprintf (NULL, 0, "%s/%s", out_dir, config_name);
+    if (n < 0)
+    {
+        fprintf (stderr, "error: failed to build logrotate config path\n");
+        free (absolute_path);
+        free (config_name);
+        return -1;
+    }
+
+    char *config_path = malloc (n + 1);
+    snprintf (config_path, n + 1, "%s/%s", out_dir, config_name);
 
     FILE *f = fopen (config_path, "w");
     if (!f)
@@ -250,23 +269,26 @@ create_logrotate_config (config_data *config)
         fprintf (stderr, "error: failed to create logrotate config: %s\n", config_path);
         free (absolute_path);
         free (config_name);
-        return;
+        free (config_path);
+        return -1;
     }
 
-    fprintf (f, "%s {\n", absolute_path);
-    fprintf (f, "    size %ldM\n", config->max_size);
-    fprintf (f, "    rotate %d\n", config->max_samples);
-    fprintf (f, "    missingok\n");
-    fprintf (f, "    notifempty\n");
-    fprintf (f, "    nocreate\n");
-    fprintf (f, "}\n");
+    fprintf (f, "%s {\n"
+             "    size %ldM\n"
+             "    rotate %d\n"
+             "    missingok\n"
+             "    notifempty\n"
+             "    nocreate\n" "}\n", absolute_path, config->max_size, config->max_samples);
 
     fclose (f);
     free (absolute_path);
     free (config_name);
+    free (config_path);
+    return 0;
 }
 
 
+/* Main function called by the GLib thread */
 static gboolean
 polling_callback (gpointer user_data)
 {
@@ -283,7 +305,7 @@ polling_callback (gpointer user_data)
     if (!json_from_tree)
     {
         fprintf (stderr, "error: could not fetch JSON from query: %s\n", config->query);
-        return G_SOURCE_CONTINUE;
+        return G_SOURCE_CONTINUE;   // Continues in case it is a temporary apteryx issue
     }
 
     if (write_diff (json_from_tree, config->destination) != 0)
@@ -291,7 +313,7 @@ polling_callback (gpointer user_data)
         fprintf (stderr, "error: could not write diff. Check destination: %s\n",
                  config->destination);
         json_decref (json_from_tree);
-        return G_SOURCE_REMOVE;
+        return G_SOURCE_REMOVE; // Breaks as the destination has likely been removed
     }
 
     json_decref (json_from_tree);
@@ -299,6 +321,7 @@ polling_callback (gpointer user_data)
     return G_SOURCE_CONTINUE;
 }
 
+/* Setup for the GLib thread */
 static gpointer
 thread_func (gpointer user_data)
 {
@@ -322,23 +345,76 @@ thread_func (gpointer user_data)
     return NULL;
 }
 
+/* Ensures there are no configs writing to the same place. Uses destination, config-file pairs*/
+static GHashTable *destination_registry = NULL;
 
-static int
-validate_destination (json_t *destination)
+static void
+destination_registry_free_all ()
 {
-    char *dest_str = strdup (json_string_value (destination));
+    if (destination_registry)
+    {
+        g_hash_table_destroy (destination_registry);
+        destination_registry = NULL;
+    }
+}
+
+/* Adds destination to table. Throws error if it is already present */
+static int
+destination_registry_add (const char *destination, const char *config_path)
+{
+    destination_registry = destination_registry ? destination_registry :
+        g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+    gchar *key = resolve_absolute_path (destination);
+
+    const char *first_seen = g_hash_table_lookup (destination_registry, key);
+    if (first_seen)
+    {
+        fprintf (stderr,
+                 "error: duplicate destination '%s' in %s "
+                 "(already registered by %s)\n",
+                 key, config_path ? config_path : "(unknown)", first_seen);
+        g_free (key);
+        return -1;
+    }
+
+    g_hash_table_insert (destination_registry, key,
+                         g_strdup (config_path ? config_path : "(unknown)"));
+    return 0;
+}
+
+/* Ensures destination can be created, and has not already been claimed */
+static int
+validate_destination (const char *destination_path, const char *config_path)
+{
+    if (!destination_path || !*destination_path)
+    {
+        fprintf (stderr, "error: destination path not provided\n");
+        return -1;
+    }
+
+    char *dest_str = strdup (destination_path);
 
     if (make_path (dest_str) != 0)
     {
-        fprintf (stderr, "error: failed to create specified destination path: %s\n", dest_str);
+        fprintf (stderr,
+                 "error: failed to create destination path: %s\n", destination_path);
+        free (dest_str);
+        return -1;
+    }
+    free (dest_str);
+
+    if (destination_registry_add (destination_path, config_path) != 0)
+    {
         return -1;
     }
 
     return 0;
 }
 
+/* Validates the data provided in the config file. Mostly checks types */
 static int
-validate_data (json_t *data, config_data *config)
+validate_data (json_t *data, config_data *config, const char *config_path)
 {
     json_t *query, *frequency, *destination, *max_samples, *max_size;
 
@@ -363,7 +439,7 @@ validate_data (json_t *data, config_data *config)
         return -1;
     }
 
-    if (validate_destination (destination) != 0)
+    if (validate_destination (json_string_value (destination), config_path) != 0)
     {
         return -1;
     }
@@ -391,8 +467,9 @@ validate_data (json_t *data, config_data *config)
     return 0;
 }
 
+/* Tries to setup thread from config file object */
 static int
-initialise_config (json_t *data)
+initialise_config (json_t *data, const char *config_path)
 {
     if (!json_is_object (data))
     {
@@ -401,21 +478,28 @@ initialise_config (json_t *data)
     }
 
     config_data *config = malloc (sizeof (config_data));
-    int result = validate_data (data, config);
-
-    if (result == -1)
+    int validation = validate_data (data, config, config_path);
+    if (validation != 0)
     {
         fprintf (stderr, "error: bad value in config \n");
         free (config);
         return -1;
     }
 
-    create_logrotate_config (config);
+    validation = create_logrotate_config (config);
+    if (validation != 0)
+    {
+        fprintf (stderr, "error: could not start logrotate \n");
+        free (config);
+        return -1;
+    }
+
     g_thread_new (NULL, thread_func, config);
 
     return 0;
 }
 
+/* Gets all JSON files from specified directory and tries to read them */
 static int
 load_configs_from_directory (const char *config_dir)
 {
@@ -452,59 +536,254 @@ load_configs_from_directory (const char *config_dir)
         if (!root)
         {
             fprintf (stderr, "error: unable to open file: %s\n", path);
-            json_decref (root);
             g_free (path);
+            closedir (dir);
             return -1;
         }
 
-        if (initialise_config (root) != 0)
+        if (initialise_config (root, path) != 0)
         {
-            fprintf (stderr, "error: failed to initialise config from file: %s\n",
-                        path);
+            fprintf (stderr, "error: failed to initialise config from file: %s\n", path);
             json_decref (root);
             g_free (path);
+            closedir (dir);
             return -1;
         }
+
+        json_decref (root);
+        g_free (path);
     }
-    
+
     closedir (dir);
     return 0;
 }
 
 
 void
-test_compare_json_deep_nulls ()
+test_compare_json_deep_both_null_returns_null ()
 {
-    json_t *old = NULL;
-    json_t *new = NULL;
-    json_t *result = NULL;
-    CU_ASSERT_PTR_NULL (compare_json_deep (old, new));
-    
-    new = json_object ();
-    result = json_null ();
-    CU_ASSERT_EQUAL (compare_json_deep (old, new), result);
-    json_decref (new);
-    json_decref (result);
+    json_t *result = compare_json_deep (NULL, NULL);
+    CU_ASSERT_PTR_NULL (result);
+}
 
-    old = json_object ();
-    new = NULL;
-    result = old;
-    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, NULL), result);
-    json_decref (old);
+void
+test_compare_json_deep_old_null_returns_json_null ()
+{
+    json_t *new_json = json_object ();
+    json_t *result = compare_json_deep (NULL, new_json);
+    json_t *expected = json_null ();
+
+    CU_ASSERT_EQUAL (result, expected);
+
+    json_decref (new_json);
+    json_decref (result);
+    json_decref (expected);
+}
+
+void
+test_compare_json_deep_new_null_returns_old_value ()
+{
+    json_t *old_json = json_object ();
+    json_t *result = compare_json_deep (old_json, NULL);
+
+    CU_ASSERT_PTR_EQUAL (result, old_json);
+
+    json_decref (old_json);
     json_decref (result);
 }
 
 void
-test_compare_json_deep_different_types ()
+test_compare_json_deep_type_mismatch_returns_old_value ()
 {
-    json_t *old = json_object ();
-    json_t *new = json_string ("new value");
-    json_t *result = old;
+    json_t *old_json = json_object ();
+    json_t *new_json = json_string ("new value");
+    json_t *result = compare_json_deep (old_json, new_json);
 
-    CU_ASSERT_PTR_EQUAL (compare_json_deep (old, new), result);
+    CU_ASSERT_PTR_EQUAL (result, old_json);
 
-    json_decref (old);
-    json_decref (new);
+    json_decref (old_json);
+    json_decref (new_json);
+    json_decref (result);
+}
+
+void
+test_compare_json_deep_equal_string_returns_null ()
+{
+    json_t *old_json = json_string ("value");
+    json_t *new_json = json_string ("value");
+    json_t *result = compare_json_deep (old_json, new_json);
+
+    CU_ASSERT_PTR_NULL (result);
+
+    json_decref (old_json);
+    json_decref (new_json);
+}
+
+void
+test_compare_json_deep_equal_integer_returns_null ()
+{
+    json_t *old_json = json_integer (42);
+    json_t *new_json = json_integer (42);
+    json_t *result = compare_json_deep (old_json, new_json);
+
+    CU_ASSERT_PTR_NULL (result);
+
+    json_decref (old_json);
+    json_decref (new_json);
+}
+
+void
+test_compare_json_deep_different_string_returns_old_value ()
+{
+    json_t *old_json = json_string ("value");
+    json_t *new_json = json_string ("new value");
+    json_t *result = compare_json_deep (old_json, new_json);
+
+    CU_ASSERT_PTR_EQUAL (result, old_json);
+
+    json_decref (old_json);
+    json_decref (new_json);
+    json_decref (result);
+}
+
+void
+test_compare_json_deep_different_integer_returns_old_value ()
+{
+    json_t *old_json = json_integer (42);
+    json_t *new_json = json_integer (41);
+    json_t *result = compare_json_deep (old_json, new_json);
+
+    CU_ASSERT_PTR_EQUAL (result, old_json);
+
+    json_decref (old_json);
+    json_decref (new_json);
+    json_decref (result);
+}
+
+
+void
+test_compare_json_deep_equal_arrays_returns_null ()
+{
+    json_t *old_arr = json_array ();
+    json_array_append_new (old_arr, json_integer (1));
+    json_array_append_new (old_arr, json_integer (2));
+    json_t *new_arr = json_array ();
+    json_array_append_new (new_arr, json_integer (1));
+    json_array_append_new (new_arr, json_integer (2));
+    json_t *result = compare_json_deep (old_arr, new_arr);
+
+    CU_ASSERT_PTR_NULL (result);
+
+    json_decref (old_arr);
+    json_decref (new_arr);
+}
+
+void
+test_compare_json_deep_different_arrays_returns_old_array ()
+{
+    json_t *old_arr = json_array ();
+    json_array_append_new (old_arr, json_integer (1));
+    json_array_append_new (old_arr, json_integer (2));
+    json_t *new_arr = json_array ();
+    json_array_append_new (new_arr, json_integer (1));
+    json_array_append_new (new_arr, json_integer (2));
+    json_array_append_new (new_arr, json_integer (3));
+    json_t *result = compare_json_deep (old_arr, new_arr);
+
+    CU_ASSERT_PTR_EQUAL (result, old_arr);
+
+    json_decref (old_arr);
+    json_decref (new_arr);
+    json_decref (result);
+}
+
+
+void
+test_compare_json_deep_empty_objects_returns_null ()
+{
+    json_t *old_obj = json_object ();
+    json_t *new_obj = json_object ();
+    json_t *result = compare_json_deep (old_obj, new_obj);
+
+    CU_ASSERT_PTR_NULL (result);
+
+    json_decref (old_obj);
+    json_decref (new_obj);
+}
+
+void
+test_compare_json_deep_equal_object_values_returns_null ()
+{
+    json_t *old_obj = json_object ();
+    json_t *new_obj = json_object ();
+    json_object_set_new (old_obj, "key1", json_string ("value"));
+    json_object_set_new (new_obj, "key1", json_string ("value"));
+    json_t *result = compare_json_deep (old_obj, new_obj);
+
+    CU_ASSERT_PTR_NULL (result);
+
+    json_decref (old_obj);
+    json_decref (new_obj);
+}
+
+
+void
+test_compare_json_deep_changed_object_value_returns_old_value_object ()
+{
+    json_t *old_obj = json_object ();
+    json_t *new_obj = json_object ();
+    json_object_set_new (old_obj, "key1", json_string ("value"));
+    json_object_set_new (new_obj, "key1", json_string ("new value"));
+    json_t *result = compare_json_deep (old_obj, new_obj);
+
+    CU_ASSERT_EQUAL (json_typeof (result), JSON_OBJECT);
+    CU_ASSERT_TRUE (json_equal (result, old_obj));
+
+    json_decref (old_obj);
+    json_decref (new_obj);
+    json_decref (result);
+}
+
+
+void
+test_compare_json_deep_added_key_returns_json_null_marker ()
+{
+    json_t *old_obj = json_object ();
+    json_t *new_obj = json_object ();
+    json_object_set_new (new_obj, "key1", json_string ("value"));
+
+    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *diff = json_object_get (result, "key1");
+    json_t *expected_null = json_null ();
+
+    CU_ASSERT_EQUAL (json_typeof (result), JSON_OBJECT);
+    CU_ASSERT_EQUAL (diff, expected_null);
+
+    json_decref (expected_null);
+    json_decref (old_obj);
+    json_decref (new_obj);
+    json_decref (result);
+}
+
+void
+test_compare_json_deep_removed_key_returns_old_value ()
+{
+    json_t *old_obj = json_object ();
+    json_t *new_obj = json_object ();
+    json_object_set_new (old_obj, "key1", json_string ("value"));
+    json_object_set_new (old_obj, "key2", json_string ("new value"));
+    json_object_set_new (new_obj, "key1", json_string ("value"));
+
+    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *diff = json_object_get (result, "key2");
+    json_t *expected = json_string ("new value");
+
+    CU_ASSERT_EQUAL (json_typeof (result), JSON_OBJECT);
+    CU_ASSERT_TRUE (json_equal (diff, expected));
+
+    json_decref (expected);
+    json_decref (old_obj);
+    json_decref (new_obj);
     json_decref (result);
 }
 
@@ -517,49 +796,80 @@ main (int argc, char *argv[])
     bool unit_test = false;
     CU_pSuite pSuite;
     GMainLoop *main_loop = NULL;
-    
+
     while ((opt = getopt (argc, argv, "huc:")) != -1)
     {
         switch (opt)
         {
-            case 'u':
-                unit_test = true;
-                break;
-            case 'c':
-                config_dir = optarg;
-                break;
+        case 'u':
+            unit_test = true;
             break;
-            case '?':
-            case 'h':
-            default:
-                printf ("Usage: %s [-h] [-u] [-c <configdir>]\n"
-                        "  -h   show this help\n"
-                        "  -u   run unit tests\n"
-                        "  -c   use files from <configdir>\n"
-                        ,argv[0]);
-                return 0;
+        case 'c':
+            config_dir = optarg;
+            break;
+        case '?':
+        case 'h':
+        default:
+            printf ("Usage: %s [-h] [-u] [-c <configdir>]\n"
+                    "  -h   show this help\n"
+                    "  -u   run unit tests\n"
+                    "  -c   use files from <configdir>\n", argv[0]);
+            return 0;
         }
     }
- 
+
 
     if (unit_test)
     {
         CU_initialize_registry ();
 
-        pSuite = CU_add_suite("compare_json_deep units", NULL, NULL);
-        CU_add_test(pSuite, "NULL values", test_compare_json_deep_nulls);
-        CU_add_test(pSuite, "differing types", test_compare_json_deep_different_types);
-        
-        CU_basic_run_tests();
-        CU_cleanup_registry();
+        pSuite = CU_add_suite ("unit::compare_json_deep", NULL, NULL);
+        CU_add_test (pSuite, "both_null_returns_null",
+                     test_compare_json_deep_both_null_returns_null);
+        CU_add_test (pSuite, "old_null_returns_json_null",
+                     test_compare_json_deep_old_null_returns_json_null);
+        CU_add_test (pSuite, "new_null_returns_old_value",
+                     test_compare_json_deep_new_null_returns_old_value);
+        CU_add_test (pSuite, "type_mismatch_returns_old_value",
+                     test_compare_json_deep_type_mismatch_returns_old_value);
+        CU_add_test (pSuite, "equal_string_returns_null",
+                     test_compare_json_deep_equal_string_returns_null);
+        CU_add_test (pSuite, "equal_integer_returns_null",
+                     test_compare_json_deep_equal_integer_returns_null);
+        CU_add_test (pSuite, "different_string_returns_old_value",
+                     test_compare_json_deep_different_string_returns_old_value);
+        CU_add_test (pSuite, "different_integer_returns_old_value",
+                     test_compare_json_deep_different_integer_returns_old_value);
+        CU_add_test (pSuite, "equal_arrays_returns_null",
+                     test_compare_json_deep_equal_arrays_returns_null);
+        CU_add_test (pSuite, "different_arrays_returns_old_array",
+                     test_compare_json_deep_different_arrays_returns_old_array);
 
-        goto exit;
+        pSuite = CU_add_suite ("integration::compare_json_deep_objects", NULL, NULL);
+        CU_add_test (pSuite, "empty_objects_returns_null",
+                     test_compare_json_deep_empty_objects_returns_null);
+        CU_add_test (pSuite, "equal_object_values_returns_null",
+                     test_compare_json_deep_equal_object_values_returns_null);
+        CU_add_test (pSuite, "changed_object_value_returns_old_value_object",
+                     test_compare_json_deep_changed_object_value_returns_old_value_object);
+        CU_add_test (pSuite, "added_key_returns_json_null_marker",
+                     test_compare_json_deep_added_key_returns_json_null_marker);
+        CU_add_test (pSuite, "removed_key_returns_old_value",
+                     test_compare_json_deep_removed_key_returns_old_value);
+
+        CU_basic_set_mode (CU_BRM_VERBOSE);
+        CU_basic_run_tests ();
+        int failures = CU_get_number_of_failures ();
+        CU_cleanup_registry ();
+
+        return failures ? -1 : 0;
     }
 
 
     if (!config_dir)
     {
-        fprintf (stderr, "error: No configuration directory path set. Missing -c <configdir>\n");
+        fprintf (stderr,
+                 "error: No configuration directory path set. Missing -c <configdir>\n");
         return -1;
     }
 
@@ -579,6 +889,9 @@ main (int argc, char *argv[])
     {
         g_main_loop_unref (main_loop);
     }
+
+    /* Cleanup destination registry */
+    destination_registry_free_all ();
 
     /* Cleanup client library */
     apteryx_shutdown ();

--- a/recorder.c
+++ b/recorder.c
@@ -24,7 +24,7 @@ static const char *logrotate_dir_override = NULL;
 #define LOGROTATE_DIR_DEFAULT "/etc/logrotate-conf.d"
 #define LOGROTATE_INCLUDE_FILE "/etc/logrotate.d/recorder"
 
-static json_t *compare_json_deep (json_t *old_json, json_t *new_json);
+static json_t *compare_json_deep (json_t *current_json, json_t *previous_json);
 
 typedef struct _config_data
 {
@@ -41,6 +41,7 @@ typedef struct _config_data
     GMutex mutex;
     GCond cond;
     gboolean thread_ready;
+    json_t *last_snapshot;
 } config_data;
 
 static GHashTable *destination_registry = NULL;
@@ -99,24 +100,24 @@ make_path (char *path)
 
 /* Compares JSON objects by comparing their individual values */
 static json_t *
-compare_objects (json_t *old_obj, json_t *new_obj)
+compare_objects (json_t *current_obj, json_t *previous_obj)
 {
     json_t *changes = json_object ();
     const char *key;
     json_t *value;
 
-    json_object_foreach (old_obj, key, value)
+    json_object_foreach (current_obj, key, value)
     {
-        json_t *diff = compare_json_deep (value, json_object_get (new_obj, key));
+        json_t *diff = compare_json_deep (value, json_object_get (previous_obj, key));
         if (diff)
         {
             json_object_set_new (changes, key, diff);
         }
     }
 
-    json_object_foreach (new_obj, key, value)
+    json_object_foreach (previous_obj, key, value)
     {
-        if (!json_object_get (old_obj, key))
+        if (!json_object_get (current_obj, key))
         {
             json_object_set_new (changes, key, json_null ());
         }
@@ -130,69 +131,235 @@ compare_objects (json_t *old_obj, json_t *new_obj)
     return changes;
 }
 
-/* Tries to compare primitively, otherwise defers to compare_objects for recursion */
+/* Compares current against previous, returning changed values for use in a forward diff. */
 static json_t *
-compare_json_deep (json_t *old_json, json_t *new_json)
+compare_json_deep (json_t *current_json, json_t *previous_json)
 {
-    if (!old_json && !new_json)
+    if (!current_json && !previous_json)
     {
         return NULL;
     }
-    if (!old_json)
+    if (!current_json)
     {
         return json_null ();
     }
-    if (!new_json)
+    if (!previous_json)
     {
-        return json_incref (old_json);
+        return json_incref (current_json);
     }
 
-    if (json_typeof (old_json) != json_typeof (new_json) ||
-        json_typeof (old_json) != JSON_OBJECT)
+    if (json_typeof (current_json) != json_typeof (previous_json) ||
+        json_typeof (current_json) != JSON_OBJECT)
     {
-        return json_equal (old_json, new_json) ? NULL : json_incref (old_json);
+        return json_equal (current_json, previous_json) ? NULL : json_incref (current_json);
     }
 
-    return compare_objects (old_json, new_json);
+    return compare_objects (current_json, previous_json);
 }
 
-/* Creates, or edits, the JSON diff file */
+
+/* Applies a forward diff to an older snapshot, determining a more recent state */
+static json_t *
+apply_forward_diff (json_t *snapshot, json_t *changes)
+{
+    if (!changes || !json_is_object (changes))
+    {
+        return json_deep_copy (snapshot);
+    }
+
+    json_t *result = json_deep_copy (snapshot);
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (changes, key, value)
+    {
+        if (json_is_null (value))
+        {
+            json_object_del (result, key);
+        }
+        else if (json_is_object (value) && json_is_object (json_object_get (result, key)))
+        {
+            json_t *nested = apply_forward_diff (json_object_get (result, key), value);
+            json_object_set_new (result, key, nested);
+        }
+        else
+        {
+            json_object_set (result, key, value);
+        }
+    }
+
+    return result;
+}
+
+/* Rebuilds the latest snapshot from a baseline + array of forward diffs */
+static json_t *
+reconstruct_latest_snapshot (json_t *baseline, json_t *diffs)
+{
+    json_t *snapshot = json_deep_copy (baseline);
+
+    for (size_t i = 0; i < json_array_size (diffs); i++)
+    {
+        json_t *entry = json_array_get (diffs, i);
+        json_t *changes = json_object_get (entry, "changes");
+        json_t *next = apply_forward_diff (snapshot, changes);
+        json_decref (snapshot);
+        snapshot = next;
+    }
+
+    return snapshot;
+}
+
+/* Appends a single entry to the diffs array via seek, minimising disk write */
 static int
-write_diff (json_t *current_json, const char *path_to_diff)
+append_diff_entry_to_file (const char *path, json_t *diff_entry)
+{
+    FILE *f = fopen (path, "r+");
+    if (!f)
+    {
+        return -1;
+    }
+
+    // Find the last ']' in the file (closing the diffs array)
+    fseek (f, 0, SEEK_END);
+    long file_size = ftell (f);
+    long pos = file_size - 1;
+
+    while (pos >= 0)
+    {
+        fseek (f, pos, SEEK_SET);
+        int ch = fgetc (f);
+        if (ch == ']')
+        {
+            break;
+        }
+        pos--;
+    }
+
+    if (pos < 0)    // No ']' in file. Likely empty.
+    {
+        fclose (f);
+        return -1;
+    }
+
+    long bracket_pos = pos;
+
+    gboolean empty_array = FALSE;
+    pos = bracket_pos - 1;
+    while (pos >= 0)
+    {
+        fseek (f, pos, SEEK_SET);
+        int ch = fgetc (f);
+        if (ch == '[')
+        {
+            empty_array = TRUE;
+            break;
+        }
+        if (!isspace (ch))
+        {
+            break;
+        }
+        pos--;
+    }
+
+    char *entry_str = json_dumps (diff_entry, JSON_COMPACT);
+    if (!entry_str) // Shouldn't happen, but prevents undefined behaviour in fprintf if NULL.
+    {
+        fclose (f);
+        return -1;
+    }
+
+    if (empty_array)
+    {
+        fseek (f, bracket_pos, SEEK_SET);
+        fprintf (f, "\n    %s\n  ]\n  }\n", entry_str);
+    }
+    else
+    {
+        // Scan to find '}' of the previous entry, so the comma trails the previous entry
+        pos = bracket_pos - 1;
+        while (pos >= 0)
+        {
+            fseek (f, pos, SEEK_SET);
+            int ch = fgetc (f);
+            if (ch == '}')
+            {
+                break;
+            }
+            pos--;
+        }
+        fseek (f, pos + 1, SEEK_SET);
+        fprintf (f, ",\n    %s\n  ]\n}\n", entry_str);
+    }
+
+    long new_end = ftell (f);
+    if (ftruncate (fileno (f), new_end) != 0) // Redundant safety net.
+    {
+        free (entry_str);
+        fclose (f);
+        return -1;
+    }
+
+    free (entry_str);
+    fclose (f);
+    return 0;
+}
+
+/* Edits (or creates) JSON diff file. Uses an in-memory cache to optimise calculations */
+static int
+write_diff (json_t *current_json, const char *path_to_diff, json_t **last_snapshot_cache)
 {
     int error_code;
     json_error_t error;
     json_t *storage = json_load_file (path_to_diff, 0, &error);
 
-    if (!storage)
+    if (!*last_snapshot_cache || !storage)
     {
-        json_t *new_storage = json_object ();
-        json_object_set_new (new_storage, "timestamp", json_integer (time (NULL)));
-        json_object_set_new (new_storage, "current", json_deep_copy (current_json));
+        if (storage)
+        {
+            // Reconstruct latest state from existing file. Likely a SIGHUP reload
+            json_t *baseline = json_object_get (storage, "baseline");
+            json_t *diffs = json_object_get (storage, "diffs");
+            *last_snapshot_cache = reconstruct_latest_snapshot (baseline, diffs);
+            json_decref (storage);
+            storage = NULL;
+        }
+        else
+        {
+            // No existing file: write baseline and set cache to current state
+            json_t *new_storage = json_object ();
+            json_object_set_new (new_storage, "baseline_timestamp",
+                                 json_integer (time (NULL)));
+            json_object_set_new (new_storage, "baseline", json_deep_copy (current_json));
+            json_object_set_new (new_storage, "diffs", json_array ());
 
-        json_t *diffs_array = json_array ();
-        json_object_set_new (new_storage, "diffs", diffs_array);
+            error_code = json_dump_file (new_storage, path_to_diff,
+                                         JSON_INDENT (json_indent));
+            json_decref (new_storage);
 
-        error_code = json_dump_file (new_storage, path_to_diff, JSON_INDENT (json_indent));
-        json_decref (new_storage);
-
-        return error_code;
+            *last_snapshot_cache = json_deep_copy (current_json);
+            return error_code;
+        }
     }
 
-    json_t *changes =
-        compare_json_deep (json_object_get (storage, "current"), current_json);
-    json_t *diff = json_object ();
+    json_t *changes = compare_json_deep (current_json, *last_snapshot_cache);
 
-    json_object_set_new (diff, "timestamp",
-                         json_deep_copy (json_object_get (storage, "timestamp")));
-    json_object_set_new (diff, "changes", changes ? changes : json_object ());
+    json_t *diff_entry = json_object ();
+    json_object_set_new (diff_entry, "timestamp", json_integer (time (NULL)));
+    json_object_set_new (diff_entry, "changes", changes ? changes : json_object ());
 
-    json_array_insert_new (json_object_get (storage, "diffs"), 0, diff);
-    json_object_set_new (storage, "timestamp", json_integer (time (NULL)));
-    json_object_set_new (storage, "current", json_deep_copy (current_json));
+    error_code = append_diff_entry_to_file (path_to_diff, diff_entry);
+    json_decref (diff_entry);
 
-    error_code = json_dump_file (storage, path_to_diff, JSON_INDENT (json_indent));
-    json_decref (storage);
+    if (error_code == 0 && changes != NULL) // Only update if there were valid changes
+    {
+        json_decref (*last_snapshot_cache);
+        *last_snapshot_cache = json_deep_copy (current_json);
+    }
+
+    if (storage)
+    {
+        json_decref (storage);
+    }
 
     return error_code;
 }
@@ -286,7 +453,7 @@ create_logrotate_config (config_data *config)
     int n = snprintf (NULL, 0, "%s/%s", out_dir, config_name);
     char *config_path = malloc (n + 1);
     snprintf (config_path, n + 1, "%s/%s", out_dir, config_name);
-    
+
     char *directory_to_write = strdup (config_path);
     if (make_path (directory_to_write) != 0)
     {
@@ -339,16 +506,16 @@ polling_callback (gpointer user_data)
 
     if (!json_from_tree)
     {
-        fprintf (stderr, "error: could not fetch JSON from query: %s\n", config->query);
+        fprintf (stderr, "warning: could not fetch JSON from query: %s\n", config->query);
         return G_SOURCE_CONTINUE;   // Continues in case it is a temporary apteryx issue
     }
 
-    if (write_diff (json_from_tree, config->destination) != 0)
+    if (write_diff (json_from_tree, config->destination, &config->last_snapshot) != 0)
     {
         fprintf (stderr, "error: could not write diff. Check destination: %s\n",
                  config->destination);
         json_decref (json_from_tree);
-        return G_SOURCE_REMOVE; // Breaks as the destination has likely been removed
+        return G_SOURCE_REMOVE; // Breaks as the destination is likely significantly broken
     }
 
     json_decref (json_from_tree);
@@ -401,7 +568,8 @@ calculate_initial_delay_at (long frequency, time_t last_poll_timestamp, time_t n
     return (guint) (frequency - elapsed);
 }
 
-/* Determines when the last poll was */
+/* Determines when the last poll was.
+ * Reads the timestamp from the last diff entry, or the baseline if no diffs exist. */
 static time_t
 read_last_poll_timestamp (const char *path_to_diff)
 {
@@ -412,9 +580,20 @@ read_last_poll_timestamp (const char *path_to_diff)
         return 0;
     }
 
-    json_t *timestamp = json_object_get (storage, "timestamp");
-    time_t result = json_is_integer (timestamp) ?
-        (time_t) json_integer_value (timestamp) : 0;
+    json_t *diffs = json_object_get (storage, "diffs");
+    size_t diffs_len = json_is_array (diffs) ? json_array_size (diffs) : 0;
+
+    if (diffs_len > 0)
+    {
+        json_t *last_diff = json_array_get (diffs, diffs_len - 1);
+        json_t *ts = json_object_get (last_diff, "timestamp");
+        time_t result = json_is_integer (ts) ? (time_t) json_integer_value (ts) : 0;
+        json_decref (storage);
+        return result;
+    }
+
+    json_t *ts = json_object_get (storage, "baseline_timestamp");
+    time_t result = json_is_integer (ts) ? (time_t) json_integer_value (ts) : 0;
 
     json_decref (storage);
     return result;
@@ -471,6 +650,10 @@ config_data_free (config_data *config)
     {
         free (config->query);
         free (config->destination);
+        if (config->last_snapshot)
+        {
+            json_decref (config->last_snapshot);
+        }
         g_mutex_clear (&config->mutex);
         g_cond_clear (&config->cond);
         free (config);
@@ -638,7 +821,7 @@ validate_destination (GHashTable *registry,
 /* Validates the data provided in the config file. Mostly checks types */
 static int
 validate_and_set_data (json_t *data,
-               config_data *config, GHashTable *registry, const char *config_path)
+                       config_data *config, GHashTable *registry, const char *config_path)
 {
     json_t *query, *frequency, *destination, *max_samples, *max_size;
 
@@ -667,7 +850,6 @@ validate_and_set_data (json_t *data,
         fprintf (stderr, "error: destination is not a string\n");
         return -1;
     }
-
     if (validate_destination (registry, json_string_value (destination), config_path) != 0)
     {
         return -1;
@@ -734,7 +916,7 @@ initialise_config (json_t *data,
     validation = create_logrotate_config (config);
     if (validation != 0)
     {
-        fprintf (stderr, "error: could not start logrotate \n");
+        fprintf (stderr, "error: could not start logrotate. Check permissions \n");
         config_data_free (config);
         return -1;
     }
@@ -788,7 +970,9 @@ load_configs_from_directory (const char *config_dir,
         root = json_load_file (path_to_file, 0, &error);
         if (!root)
         {
-            fprintf (stderr, "error: unable to open file: %s. May be empty or have too many objects\n", path_to_file);
+            fprintf (stderr,
+                     "error: unable to open file: %s. May be empty or have too many objects\n",
+                     path_to_file);
             free (absolute_config_dir);
             g_free (path_to_file);
             closedir (dir);
@@ -797,7 +981,8 @@ load_configs_from_directory (const char *config_dir,
 
         if (initialise_config (root, path_to_file, registry, configs) != 0)
         {
-            fprintf (stderr, "error: failed to initialise config from file: %s\n", path_to_file);
+            fprintf (stderr, "error: failed to initialise config from file: %s\n",
+                     path_to_file);
             free (absolute_config_dir);
             g_free (path_to_file);
             json_decref (root);
@@ -814,7 +999,8 @@ load_configs_from_directory (const char *config_dir,
 
     if (configs->len == 0)
     {
-        fprintf (stderr, "error: no valid .json config files found in directory: %s\n", config_dir);
+        fprintf (stderr, "error: no valid .json config files found in directory: %s\n",
+                 config_dir);
         return -1;
     }
     return 0;
@@ -877,7 +1063,7 @@ reload_handler (gpointer user_data)
 
     if (replace_active_configs (config_dir) != 0)
     {
-        fprintf (stderr, "error: failed to reload configs from %s\n", config_dir); // Keeps running with old configs if reload fails
+        fprintf (stderr, "error: failed to reload configs from %s\n", config_dir);  // Keeps running with old configs if reload fails
     }
 
     return G_SOURCE_CONTINUE;
@@ -892,192 +1078,188 @@ test_compare_json_deep_both_null_returns_null ()
 }
 
 void
-test_compare_json_deep_old_null_returns_json_null ()
+test_compare_json_deep_current_null_returns_json_null ()
 {
-    json_t *new_json = json_object ();
-    json_t *result = compare_json_deep (NULL, new_json);
+    json_t *previous_json = json_object ();
+    json_t *result = compare_json_deep (NULL, previous_json);
     json_t *expected = json_null ();
 
     CU_ASSERT_EQUAL (result, expected);
 
-    json_decref (new_json);
+    json_decref (previous_json);
     json_decref (result);
     json_decref (expected);
 }
 
 void
-test_compare_json_deep_new_null_returns_old_value ()
+test_compare_json_deep_previous_null_returns_current_value ()
 {
-    json_t *old_json = json_object ();
-    json_t *result = compare_json_deep (old_json, NULL);
+    json_t *current_json = json_object ();
+    json_t *result = compare_json_deep (current_json, NULL);
 
-    CU_ASSERT_PTR_EQUAL (result, old_json);
+    CU_ASSERT_PTR_EQUAL (result, current_json);
 
-    json_decref (old_json);
+    json_decref (current_json);
     json_decref (result);
 }
 
 void
-test_compare_json_deep_type_mismatch_returns_old_value ()
+test_compare_json_deep_type_mismatch_returns_current_value ()
 {
-    json_t *old_json = json_object ();
-    json_t *new_json = json_string ("new value");
-    json_t *result = compare_json_deep (old_json, new_json);
+    json_t *current_json = json_object ();
+    json_t *previous_json = json_string ("previous value");
+    json_t *result = compare_json_deep (current_json, previous_json);
 
-    CU_ASSERT_PTR_EQUAL (result, old_json);
+    CU_ASSERT_PTR_EQUAL (result, current_json);
 
-    json_decref (old_json);
-    json_decref (new_json);
+    json_decref (current_json);
+    json_decref (previous_json);
     json_decref (result);
 }
 
 void
 test_compare_json_deep_equal_string_returns_null ()
 {
-    json_t *old_json = json_string ("value");
-    json_t *new_json = json_string ("value");
-    json_t *result = compare_json_deep (old_json, new_json);
+    json_t *current_json = json_string ("value");
+    json_t *previous_json = json_string ("value");
+    json_t *result = compare_json_deep (current_json, previous_json);
 
     CU_ASSERT_PTR_NULL (result);
 
-    json_decref (old_json);
-    json_decref (new_json);
+    json_decref (current_json);
+    json_decref (previous_json);
 }
 
 void
 test_compare_json_deep_equal_integer_returns_null ()
 {
-    json_t *old_json = json_integer (42);
-    json_t *new_json = json_integer (42);
-    json_t *result = compare_json_deep (old_json, new_json);
+    json_t *current_json = json_integer (42);
+    json_t *previous_json = json_integer (42);
+    json_t *result = compare_json_deep (current_json, previous_json);
 
     CU_ASSERT_PTR_NULL (result);
 
-    json_decref (old_json);
-    json_decref (new_json);
+    json_decref (current_json);
+    json_decref (previous_json);
 }
 
 void
-test_compare_json_deep_different_string_returns_old_value ()
+test_compare_json_deep_different_string_returns_current_value ()
 {
-    json_t *old_json = json_string ("value");
-    json_t *new_json = json_string ("new value");
-    json_t *result = compare_json_deep (old_json, new_json);
+    json_t *current_json = json_string ("new value");
+    json_t *previous_json = json_string ("old value");
+    json_t *result = compare_json_deep (current_json, previous_json);
 
-    CU_ASSERT_PTR_EQUAL (result, old_json);
+    CU_ASSERT_PTR_EQUAL (result, current_json);
 
-    json_decref (old_json);
-    json_decref (new_json);
+    json_decref (current_json);
+    json_decref (previous_json);
     json_decref (result);
 }
 
 void
-test_compare_json_deep_different_integer_returns_old_value ()
+test_compare_json_deep_different_integer_returns_current_value ()
 {
-    json_t *old_json = json_integer (42);
-    json_t *new_json = json_integer (41);
-    json_t *result = compare_json_deep (old_json, new_json);
+    json_t *current_json = json_integer (42);
+    json_t *previous_json = json_integer (41);
+    json_t *result = compare_json_deep (current_json, previous_json);
 
-    CU_ASSERT_PTR_EQUAL (result, old_json);
+    CU_ASSERT_PTR_EQUAL (result, current_json);
 
-    json_decref (old_json);
-    json_decref (new_json);
+    json_decref (current_json);
+    json_decref (previous_json);
     json_decref (result);
 }
-
 
 void
 test_compare_json_deep_equal_arrays_returns_null ()
 {
-    json_t *old_arr = json_array ();
-    json_array_append_new (old_arr, json_integer (1));
-    json_array_append_new (old_arr, json_integer (2));
-    json_t *new_arr = json_array ();
-    json_array_append_new (new_arr, json_integer (1));
-    json_array_append_new (new_arr, json_integer (2));
-    json_t *result = compare_json_deep (old_arr, new_arr);
+    json_t *current_arr = json_array ();
+    json_array_append_new (current_arr, json_integer (1));
+    json_array_append_new (current_arr, json_integer (2));
+    json_t *previous_arr = json_array ();
+    json_array_append_new (previous_arr, json_integer (1));
+    json_array_append_new (previous_arr, json_integer (2));
+    json_t *result = compare_json_deep (current_arr, previous_arr);
 
     CU_ASSERT_PTR_NULL (result);
 
-    json_decref (old_arr);
-    json_decref (new_arr);
+    json_decref (current_arr);
+    json_decref (previous_arr);
 }
 
 void
-test_compare_json_deep_different_arrays_returns_old_array ()
+test_compare_json_deep_different_arrays_returns_current_array ()
 {
-    json_t *old_arr = json_array ();
-    json_array_append_new (old_arr, json_integer (1));
-    json_array_append_new (old_arr, json_integer (2));
-    json_t *new_arr = json_array ();
-    json_array_append_new (new_arr, json_integer (1));
-    json_array_append_new (new_arr, json_integer (2));
-    json_array_append_new (new_arr, json_integer (3));
-    json_t *result = compare_json_deep (old_arr, new_arr);
+    json_t *current_arr = json_array ();
+    json_array_append_new (current_arr, json_integer (1));
+    json_array_append_new (current_arr, json_integer (2));
+    json_array_append_new (current_arr, json_integer (3));
+    json_t *previous_arr = json_array ();
+    json_array_append_new (previous_arr, json_integer (1));
+    json_array_append_new (previous_arr, json_integer (2));
+    json_t *result = compare_json_deep (current_arr, previous_arr);
 
-    CU_ASSERT_PTR_EQUAL (result, old_arr);
+    CU_ASSERT_PTR_EQUAL (result, current_arr);
 
-    json_decref (old_arr);
-    json_decref (new_arr);
+    json_decref (current_arr);
+    json_decref (previous_arr);
     json_decref (result);
 }
-
 
 void
 test_compare_json_deep_empty_objects_returns_null ()
 {
-    json_t *old_obj = json_object ();
-    json_t *new_obj = json_object ();
-    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *current_obj = json_object ();
+    json_t *previous_obj = json_object ();
+    json_t *result = compare_json_deep (current_obj, previous_obj);
 
     CU_ASSERT_PTR_NULL (result);
 
-    json_decref (old_obj);
-    json_decref (new_obj);
+    json_decref (current_obj);
+    json_decref (previous_obj);
 }
 
 void
 test_compare_json_deep_equal_object_values_returns_null ()
 {
-    json_t *old_obj = json_object ();
-    json_t *new_obj = json_object ();
-    json_object_set_new (old_obj, "key1", json_string ("value"));
-    json_object_set_new (new_obj, "key1", json_string ("value"));
-    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *current_obj = json_object ();
+    json_t *previous_obj = json_object ();
+    json_object_set_new (current_obj, "key1", json_string ("value"));
+    json_object_set_new (previous_obj, "key1", json_string ("value"));
+    json_t *result = compare_json_deep (current_obj, previous_obj);
 
     CU_ASSERT_PTR_NULL (result);
 
-    json_decref (old_obj);
-    json_decref (new_obj);
+    json_decref (current_obj);
+    json_decref (previous_obj);
 }
 
-
 void
-test_compare_json_deep_changed_object_value_returns_old_value_object ()
+test_compare_json_deep_changed_object_value_returns_current_value_object ()
 {
-    json_t *old_obj = json_object ();
-    json_t *new_obj = json_object ();
-    json_object_set_new (old_obj, "key1", json_string ("value"));
-    json_object_set_new (new_obj, "key1", json_string ("new value"));
-    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *current_obj = json_object ();
+    json_t *previous_obj = json_object ();
+    json_object_set_new (current_obj, "key1", json_string ("new value"));
+    json_object_set_new (previous_obj, "key1", json_string ("old value"));
+    json_t *result = compare_json_deep (current_obj, previous_obj);
 
     CU_ASSERT_EQUAL (json_typeof (result), JSON_OBJECT);
-    CU_ASSERT_TRUE (json_equal (result, old_obj));
+    CU_ASSERT_TRUE (json_equal (result, current_obj));
 
-    json_decref (old_obj);
-    json_decref (new_obj);
+    json_decref (current_obj);
+    json_decref (previous_obj);
     json_decref (result);
 }
 
-
 void
-test_compare_json_deep_added_key_returns_json_null_marker ()
+test_compare_json_deep_deleted_key_records_null_marker ()
 {
-    json_t *old_obj = json_object ();
-    json_t *new_obj = json_object ();
-    json_object_set_new (new_obj, "key1", json_string ("value"));
+    json_t *current_obj = json_object ();
+    json_t *previous_obj = json_object ();
+    json_object_set_new (previous_obj, "key1", json_string ("value"));
 
-    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *result = compare_json_deep (current_obj, previous_obj);
     json_t *diff = json_object_get (result, "key1");
     json_t *expected_null = json_null ();
 
@@ -1085,21 +1267,21 @@ test_compare_json_deep_added_key_returns_json_null_marker ()
     CU_ASSERT_EQUAL (diff, expected_null);
 
     json_decref (expected_null);
-    json_decref (old_obj);
-    json_decref (new_obj);
+    json_decref (current_obj);
+    json_decref (previous_obj);
     json_decref (result);
 }
 
 void
-test_compare_json_deep_removed_key_returns_old_value ()
+test_compare_json_deep_new_key_returns_current_value ()
 {
-    json_t *old_obj = json_object ();
-    json_t *new_obj = json_object ();
-    json_object_set_new (old_obj, "key1", json_string ("value"));
-    json_object_set_new (old_obj, "key2", json_string ("new value"));
-    json_object_set_new (new_obj, "key1", json_string ("value"));
+    json_t *current_obj = json_object ();
+    json_t *previous_obj = json_object ();
+    json_object_set_new (current_obj, "key1", json_string ("value"));
+    json_object_set_new (current_obj, "key2", json_string ("new value"));
+    json_object_set_new (previous_obj, "key1", json_string ("value"));
 
-    json_t *result = compare_json_deep (old_obj, new_obj);
+    json_t *result = compare_json_deep (current_obj, previous_obj);
     json_t *diff = json_object_get (result, "key2");
     json_t *expected = json_string ("new value");
 
@@ -1107,10 +1289,11 @@ test_compare_json_deep_removed_key_returns_old_value ()
     CU_ASSERT_TRUE (json_equal (diff, expected));
 
     json_decref (expected);
-    json_decref (old_obj);
-    json_decref (new_obj);
+    json_decref (current_obj);
+    json_decref (previous_obj);
     json_decref (result);
 }
+
 
 void
 test_calculate_initial_delay_at_missing_timestamp_returns_frequency ()
@@ -1150,8 +1333,11 @@ write_test_timestamp_file (const char *path_to_diff, json_t *timestamp)
 
     if (timestamp)
     {
-        json_object_set (root, "timestamp", timestamp);
+        json_object_set (root, "baseline_timestamp", timestamp);
     }
+
+    json_object_set_new (root, "baseline", json_object ());
+    json_object_set_new (root, "diffs", json_array ());
 
     int rc = json_dump_file (root, path_to_diff, 0);
     json_decref (root);
@@ -1194,6 +1380,547 @@ test_read_last_poll_timestamp_non_integer_returns_zero ()
 
     unlink (path);
     json_decref (timestamp);
+}
+
+
+void
+test_apply_forward_diff_null_changes_returns_copy ()
+{
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("val"));
+
+    json_t *result = apply_forward_diff (snapshot, NULL);
+
+    CU_ASSERT_TRUE (json_equal (result, snapshot));
+    CU_ASSERT_PTR_NOT_EQUAL (result, snapshot);
+
+    json_decref (snapshot);
+    json_decref (result);
+}
+
+void
+test_apply_forward_diff_empty_changes_returns_copy ()
+{
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("val"));
+    json_t *changes = json_object ();
+
+    json_t *result = apply_forward_diff (snapshot, changes);
+
+    CU_ASSERT_TRUE (json_equal (result, snapshot));
+    CU_ASSERT_PTR_NOT_EQUAL (result, snapshot);
+
+    json_decref (snapshot);
+    json_decref (changes);
+    json_decref (result);
+}
+
+void
+test_apply_forward_diff_updates_existing_key ()
+{
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("old"));
+    json_t *changes = json_object ();
+    json_object_set_new (changes, "key", json_string ("new"));
+
+    json_t *result = apply_forward_diff (snapshot, changes);
+    json_t *expected = json_string ("new");
+
+    CU_ASSERT_TRUE (json_equal (json_object_get (result, "key"), expected));
+
+    json_decref (snapshot);
+    json_decref (changes);
+    json_decref (result);
+    json_decref (expected);
+}
+
+void
+test_apply_forward_diff_adds_new_key ()
+{
+    json_t *snapshot = json_object ();
+    json_t *changes = json_object ();
+    json_object_set_new (changes, "added", json_string ("value"));
+
+    json_t *result = apply_forward_diff (snapshot, changes);
+
+    CU_ASSERT_PTR_NOT_NULL (json_object_get (result, "added"));
+    CU_ASSERT_TRUE (json_equal (json_object_get (result, "added"),
+                                json_object_get (changes, "added")));
+
+    json_decref (snapshot);
+    json_decref (changes);
+    json_decref (result);
+}
+
+void
+test_apply_forward_diff_null_value_deletes_key ()
+{
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("val"));
+    json_t *changes = json_object ();
+    json_object_set_new (changes, "key", json_null ());
+
+    json_t *result = apply_forward_diff (snapshot, changes);
+
+    CU_ASSERT_PTR_NULL (json_object_get (result, "key"));
+    CU_ASSERT_EQUAL (json_object_size (result), 0);
+
+    json_decref (snapshot);
+    json_decref (changes);
+    json_decref (result);
+}
+
+void
+test_apply_forward_diff_nested_object_merges ()
+{
+    json_t *inner = json_object ();
+    json_object_set_new (inner, "a", json_string ("1"));
+    json_object_set_new (inner, "b", json_string ("2"));
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "nested", inner);
+
+    json_t *inner_change = json_object ();
+    json_object_set_new (inner_change, "b", json_string ("changed"));
+    json_t *changes = json_object ();
+    json_object_set_new (changes, "nested", inner_change);
+
+    json_t *result = apply_forward_diff (snapshot, changes);
+    json_t *result_nested = json_object_get (result, "nested");
+
+    CU_ASSERT_STRING_EQUAL (json_string_value (json_object_get (result_nested, "a")), "1");
+    CU_ASSERT_STRING_EQUAL (json_string_value (json_object_get (result_nested, "b")),
+                            "changed");
+
+    json_decref (snapshot);
+    json_decref (changes);
+    json_decref (result);
+}
+
+
+void
+test_reconstruct_no_diffs_returns_baseline ()
+{
+    json_t *baseline = json_object ();
+    json_object_set_new (baseline, "key", json_string ("val"));
+    json_t *diffs = json_array ();
+
+    json_t *result = reconstruct_latest_snapshot (baseline, diffs);
+
+    CU_ASSERT_TRUE (json_equal (result, baseline));
+    CU_ASSERT_PTR_NOT_EQUAL (result, baseline);
+
+    json_decref (baseline);
+    json_decref (diffs);
+    json_decref (result);
+}
+
+void
+test_reconstruct_single_diff_applies ()
+{
+    json_t *baseline = json_object ();
+    json_object_set_new (baseline, "key", json_string ("v1"));
+
+    json_t *diff_changes = json_object ();
+    json_object_set_new (diff_changes, "key", json_string ("v2"));
+    json_t *diff_entry = json_object ();
+    json_object_set_new (diff_entry, "changes", diff_changes);
+
+    json_t *diffs = json_array ();
+    json_array_append_new (diffs, diff_entry);
+
+    json_t *result = reconstruct_latest_snapshot (baseline, diffs);
+    json_t *expected = json_string ("v2");
+
+    CU_ASSERT_TRUE (json_equal (json_object_get (result, "key"), expected));
+
+    json_decref (baseline);
+    json_decref (diffs);
+    json_decref (result);
+    json_decref (expected);
+}
+
+void
+test_reconstruct_multiple_diffs_applies_in_order ()
+{
+    json_t *baseline = json_object ();
+    json_object_set_new (baseline, "key", json_string ("v1"));
+
+    json_t *d1_changes = json_object ();
+    json_object_set_new (d1_changes, "key", json_string ("v2"));
+    json_t *d1 = json_object ();
+    json_object_set_new (d1, "changes", d1_changes);
+
+    json_t *d2_changes = json_object ();
+    json_object_set_new (d2_changes, "key", json_string ("v3"));
+    json_t *d2 = json_object ();
+    json_object_set_new (d2, "changes", d2_changes);
+
+    json_t *diffs = json_array ();
+    json_array_append_new (diffs, d1);
+    json_array_append_new (diffs, d2);
+
+    json_t *result = reconstruct_latest_snapshot (baseline, diffs);
+
+    CU_ASSERT_STRING_EQUAL (json_string_value (json_object_get (result, "key")), "v3");
+
+    json_decref (baseline);
+    json_decref (diffs);
+    json_decref (result);
+}
+
+void
+test_reconstruct_diff_with_deletion ()
+{
+    json_t *baseline = json_object ();
+    json_object_set_new (baseline, "a", json_string ("1"));
+    json_object_set_new (baseline, "b", json_string ("2"));
+
+    json_t *changes = json_object ();
+    json_object_set_new (changes, "b", json_null ());
+    json_t *d = json_object ();
+    json_object_set_new (d, "changes", changes);
+
+    json_t *diffs = json_array ();
+    json_array_append_new (diffs, d);
+
+    json_t *result = reconstruct_latest_snapshot (baseline, diffs);
+
+    CU_ASSERT_PTR_NOT_NULL (json_object_get (result, "a"));
+    CU_ASSERT_PTR_NULL (json_object_get (result, "b"));
+
+    json_decref (baseline);
+    json_decref (diffs);
+    json_decref (result);
+}
+
+
+void
+test_append_diff_to_empty_array ()
+{
+    char path[] = "/tmp/recorder_append_empty_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+
+    /* Write a minimal valid file with empty diffs array */
+    json_t *storage = json_object ();
+    json_object_set_new (storage, "baseline_timestamp", json_integer (100));
+    json_object_set_new (storage, "baseline", json_object ());
+    json_object_set_new (storage, "diffs", json_array ());
+    CU_ASSERT_EQUAL_FATAL (json_dump_file (storage, path, JSON_INDENT (json_indent)), 0);
+    json_decref (storage);
+
+    json_t *entry = json_object ();
+    json_object_set_new (entry, "timestamp", json_integer (200));
+    json_object_set_new (entry, "changes", json_object ());
+
+    CU_ASSERT_EQUAL (append_diff_entry_to_file (path, entry), 0);
+    json_decref (entry);
+
+    /* Verify the file is still valid JSON with one diff */
+    json_error_t error;
+    json_t *reloaded = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (reloaded);
+
+    json_t *diffs = json_object_get (reloaded, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 1);
+    CU_ASSERT_EQUAL (json_integer_value
+                     (json_object_get (json_array_get (diffs, 0), "timestamp")), 200);
+
+    json_decref (reloaded);
+    unlink (path);
+}
+
+void
+test_append_diff_to_nonempty_array ()
+{
+    char path[] = "/tmp/recorder_append_nonempty_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+
+    /* Write file with one existing diff */
+    json_t *existing_entry = json_object ();
+    json_object_set_new (existing_entry, "timestamp", json_integer (100));
+    json_object_set_new (existing_entry, "changes", json_object ());
+    json_t *diffs_arr = json_array ();
+    json_array_append_new (diffs_arr, existing_entry);
+
+    json_t *storage = json_object ();
+    json_object_set_new (storage, "baseline_timestamp", json_integer (50));
+    json_object_set_new (storage, "baseline", json_object ());
+    json_object_set_new (storage, "diffs", diffs_arr);
+    CU_ASSERT_EQUAL_FATAL (json_dump_file (storage, path, JSON_INDENT (json_indent)), 0);
+    json_decref (storage);
+
+    json_t *entry = json_object ();
+    json_object_set_new (entry, "timestamp", json_integer (200));
+    json_object_set_new (entry, "changes", json_object ());
+
+    CU_ASSERT_EQUAL (append_diff_entry_to_file (path, entry), 0);
+    json_decref (entry);
+
+    json_error_t error;
+    json_t *reloaded = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (reloaded);
+
+    json_t *diffs = json_object_get (reloaded, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 2);
+    CU_ASSERT_EQUAL (json_integer_value
+                     (json_object_get (json_array_get (diffs, 0), "timestamp")), 100);
+    CU_ASSERT_EQUAL (json_integer_value
+                     (json_object_get (json_array_get (diffs, 1), "timestamp")), 200);
+
+    json_decref (reloaded);
+    unlink (path);
+}
+
+void
+test_append_diff_nonexistent_file_fails ()
+{
+    json_t *entry = json_object ();
+    json_object_set_new (entry, "timestamp", json_integer (100));
+    json_object_set_new (entry, "changes", json_object ());
+
+    CU_ASSERT_NOT_EQUAL (append_diff_entry_to_file
+                         ("/tmp/recorder_nonexistent_file_xyz", entry), 0);
+
+    json_decref (entry);
+}
+
+
+void
+test_write_diff_creates_baseline_on_new_file ()
+{
+    char path[] = "/tmp/recorder_wd_new_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+    unlink (path);  /* Ensure file does not exist */
+
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("val"));
+    json_t *cache = NULL;
+
+    CU_ASSERT_EQUAL (write_diff (snapshot, path, &cache), 0);
+    CU_ASSERT_PTR_NOT_NULL (cache);
+
+    /* Verify file structure */
+    json_error_t error;
+    json_t *storage = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (storage);
+    CU_ASSERT_PTR_NOT_NULL (json_object_get (storage, "baseline"));
+    CU_ASSERT_PTR_NOT_NULL (json_object_get (storage, "baseline_timestamp"));
+    CU_ASSERT_TRUE (json_equal (json_object_get (storage, "baseline"), snapshot));
+    CU_ASSERT_EQUAL (json_array_size (json_object_get (storage, "diffs")), 0);
+
+    json_decref (storage);
+    json_decref (snapshot);
+    json_decref (cache);
+    unlink (path);
+}
+
+void
+test_write_diff_appends_empty_diff_when_unchanged ()
+{
+    char path[] = "/tmp/recorder_wd_unchanged_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+    unlink (path);
+
+    json_t *snapshot = json_object ();
+    json_object_set_new (snapshot, "key", json_string ("val"));
+    json_t *cache = NULL;
+
+    /* First call creates baseline */
+    CU_ASSERT_EQUAL (write_diff (snapshot, path, &cache), 0);
+    /* Second call with same data */
+    CU_ASSERT_EQUAL (write_diff (snapshot, path, &cache), 0);
+
+    json_error_t error;
+    json_t *storage = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (storage);
+
+    json_t *diffs = json_object_get (storage, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 1);
+
+    /* Changes should be empty object */
+    json_t *first_diff = json_array_get (diffs, 0);
+    json_t *changes = json_object_get (first_diff, "changes");
+    CU_ASSERT_EQUAL (json_object_size (changes), 0);
+
+    json_decref (storage);
+    json_decref (snapshot);
+    json_decref (cache);
+    unlink (path);
+}
+
+void
+test_write_diff_records_changes ()
+{
+    char path[] = "/tmp/recorder_wd_changes_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+    unlink (path);
+
+    json_t *snap1 = json_object ();
+    json_object_set_new (snap1, "key", json_string ("v1"));
+    json_t *cache = NULL;
+
+    CU_ASSERT_EQUAL (write_diff (snap1, path, &cache), 0);
+
+    json_t *snap2 = json_object ();
+    json_object_set_new (snap2, "key", json_string ("v2"));
+
+    CU_ASSERT_EQUAL (write_diff (snap2, path, &cache), 0);
+
+    json_error_t error;
+    json_t *storage = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (storage);
+
+    /* Baseline should still be v1 */
+    CU_ASSERT_STRING_EQUAL (json_string_value
+                            (json_object_get
+                             (json_object_get (storage, "baseline"), "key")), "v1");
+
+    /* Diff should record the new value v2 */
+    json_t *diffs = json_object_get (storage, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 1);
+    json_t *changes = json_object_get (json_array_get (diffs, 0), "changes");
+    CU_ASSERT_STRING_EQUAL (json_string_value (json_object_get (changes, "key")), "v2");
+
+    json_decref (storage);
+    json_decref (snap1);
+    json_decref (snap2);
+    json_decref (cache);
+    unlink (path);
+}
+
+void
+test_write_diff_multiple_polls_accumulates_diffs ()
+{
+    char path[] = "/tmp/recorder_wd_multi_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+    unlink (path);
+
+    json_t *cache = NULL;
+
+    json_t *s1 = json_object ();
+    json_object_set_new (s1, "key", json_string ("v1"));
+    CU_ASSERT_EQUAL (write_diff (s1, path, &cache), 0);
+
+    json_t *s2 = json_object ();
+    json_object_set_new (s2, "key", json_string ("v2"));
+    CU_ASSERT_EQUAL (write_diff (s2, path, &cache), 0);
+
+    json_t *s3 = json_object ();
+    json_object_set_new (s3, "key", json_string ("v3"));
+    CU_ASSERT_EQUAL (write_diff (s3, path, &cache), 0);
+
+    /* Same as s3 - empty diff */
+    CU_ASSERT_EQUAL (write_diff (s3, path, &cache), 0);
+
+    json_error_t error;
+    json_t *storage = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (storage);
+
+    json_t *diffs = json_object_get (storage, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 3);
+
+    /* Verify baseline untouched */
+    CU_ASSERT_STRING_EQUAL (json_string_value
+                            (json_object_get
+                             (json_object_get (storage, "baseline"), "key")), "v1");
+
+    json_decref (storage);
+    json_decref (s1);
+    json_decref (s2);
+    json_decref (s3);
+    json_decref (cache);
+    unlink (path);
+}
+
+void
+test_write_diff_reconstruct_from_existing_file ()
+{
+    char path[] = "/tmp/recorder_wd_recon_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+    unlink (path);
+
+    /* Simulate first session: write baseline + one diff */
+    json_t *cache1 = NULL;
+    json_t *s1 = json_object ();
+    json_object_set_new (s1, "key", json_string ("v1"));
+    CU_ASSERT_EQUAL (write_diff (s1, path, &cache1), 0);
+
+    json_t *s2 = json_object ();
+    json_object_set_new (s2, "key", json_string ("v2"));
+    CU_ASSERT_EQUAL (write_diff (s2, path, &cache1), 0);
+    json_decref (cache1);
+
+    /* Simulate restart: new cache, same file */
+    json_t *cache2 = NULL;
+    json_t *s3 = json_object ();
+    json_object_set_new (s3, "key", json_string ("v3"));
+    CU_ASSERT_EQUAL (write_diff (s3, path, &cache2), 0);
+
+    /* Verify: baseline=v1, diffs=[v2_change, v3_change] */
+    json_error_t error;
+    json_t *storage = json_load_file (path, 0, &error);
+    CU_ASSERT_PTR_NOT_NULL_FATAL (storage);
+
+    CU_ASSERT_STRING_EQUAL (json_string_value
+                            (json_object_get
+                             (json_object_get (storage, "baseline"), "key")), "v1");
+
+    json_t *diffs = json_object_get (storage, "diffs");
+    CU_ASSERT_EQUAL (json_array_size (diffs), 2);
+
+    /* The second diff should have v3 as the new value */
+    json_t *last_changes = json_object_get (json_array_get (diffs, 1), "changes");
+    CU_ASSERT_STRING_EQUAL (json_string_value (json_object_get (last_changes, "key")),
+                            "v3");
+
+    json_decref (storage);
+    json_decref (s1);
+    json_decref (s2);
+    json_decref (s3);
+    json_decref (cache2);
+    unlink (path);
+}
+
+void
+test_read_last_poll_timestamp_reads_from_diffs ()
+{
+    char path[] = "/tmp/recorder_ts_diffs_XXXXXX";
+    int fd = mkstemp (path);
+    CU_ASSERT_NOT_EQUAL_FATAL (fd, -1);
+    close (fd);
+
+    /* Write file with a diff entry that has a known timestamp */
+    json_t *diff_entry = json_object ();
+    json_object_set_new (diff_entry, "timestamp", json_integer (9999));
+    json_object_set_new (diff_entry, "changes", json_object ());
+    json_t *diffs_arr = json_array ();
+    json_array_append_new (diffs_arr, diff_entry);
+
+    json_t *storage = json_object ();
+    json_object_set_new (storage, "baseline_timestamp", json_integer (1000));
+    json_object_set_new (storage, "baseline", json_object ());
+    json_object_set_new (storage, "diffs", diffs_arr);
+    CU_ASSERT_EQUAL_FATAL (json_dump_file (storage, path, 0), 0);
+    json_decref (storage);
+
+    time_t result = read_last_poll_timestamp (path);
+    CU_ASSERT_EQUAL (result, 9999);
+
+    unlink (path);
 }
 
 
@@ -1240,36 +1967,36 @@ main (int argc, char *argv[])
         pSuite = CU_add_suite ("unit::compare_json_deep", NULL, NULL);
         CU_add_test (pSuite, "both_null_returns_null",
                      test_compare_json_deep_both_null_returns_null);
-        CU_add_test (pSuite, "old_null_returns_json_null",
-                     test_compare_json_deep_old_null_returns_json_null);
-        CU_add_test (pSuite, "new_null_returns_old_value",
-                     test_compare_json_deep_new_null_returns_old_value);
-        CU_add_test (pSuite, "type_mismatch_returns_old_value",
-                     test_compare_json_deep_type_mismatch_returns_old_value);
+        CU_add_test (pSuite, "current_null_returns_json_null",
+                     test_compare_json_deep_current_null_returns_json_null);
+        CU_add_test (pSuite, "previous_null_returns_current_value",
+                     test_compare_json_deep_previous_null_returns_current_value);
+        CU_add_test (pSuite, "type_mismatch_returns_current_value",
+                     test_compare_json_deep_type_mismatch_returns_current_value);
         CU_add_test (pSuite, "equal_string_returns_null",
                      test_compare_json_deep_equal_string_returns_null);
         CU_add_test (pSuite, "equal_integer_returns_null",
                      test_compare_json_deep_equal_integer_returns_null);
-        CU_add_test (pSuite, "different_string_returns_old_value",
-                     test_compare_json_deep_different_string_returns_old_value);
-        CU_add_test (pSuite, "different_integer_returns_old_value",
-                     test_compare_json_deep_different_integer_returns_old_value);
+        CU_add_test (pSuite, "different_string_returns_current_value",
+                     test_compare_json_deep_different_string_returns_current_value);
+        CU_add_test (pSuite, "different_integer_returns_current_value",
+                     test_compare_json_deep_different_integer_returns_current_value);
         CU_add_test (pSuite, "equal_arrays_returns_null",
                      test_compare_json_deep_equal_arrays_returns_null);
-        CU_add_test (pSuite, "different_arrays_returns_old_array",
-                     test_compare_json_deep_different_arrays_returns_old_array);
+        CU_add_test (pSuite, "different_arrays_returns_current_array",
+                     test_compare_json_deep_different_arrays_returns_current_array);
 
         pSuite = CU_add_suite ("integration::compare_json_deep_objects", NULL, NULL);
         CU_add_test (pSuite, "empty_objects_returns_null",
                      test_compare_json_deep_empty_objects_returns_null);
         CU_add_test (pSuite, "equal_object_values_returns_null",
                      test_compare_json_deep_equal_object_values_returns_null);
-        CU_add_test (pSuite, "changed_object_value_returns_old_value_object",
-                     test_compare_json_deep_changed_object_value_returns_old_value_object);
-        CU_add_test (pSuite, "added_key_returns_json_null_marker",
-                     test_compare_json_deep_added_key_returns_json_null_marker);
-        CU_add_test (pSuite, "removed_key_returns_old_value",
-                     test_compare_json_deep_removed_key_returns_old_value);
+        CU_add_test (pSuite, "changed_object_value_returns_current_value_object",
+                     test_compare_json_deep_changed_object_value_returns_current_value_object);
+        CU_add_test (pSuite, "deleted_key_records_null_marker",
+                     test_compare_json_deep_deleted_key_records_null_marker);
+        CU_add_test (pSuite, "new_key_returns_current_value",
+                     test_compare_json_deep_new_key_returns_current_value);
 
         pSuite = CU_add_suite ("unit::reload_timing", NULL, NULL);
         CU_add_test (pSuite, "missing_timestamp_returns_frequency",
@@ -1286,6 +2013,47 @@ main (int argc, char *argv[])
                      test_read_last_poll_timestamp_valid_file_returns_value);
         CU_add_test (pSuite, "non_integer_returns_zero",
                      test_read_last_poll_timestamp_non_integer_returns_zero);
+        CU_add_test (pSuite, "reads_timestamp_from_last_diff",
+                     test_read_last_poll_timestamp_reads_from_diffs);
+
+        pSuite = CU_add_suite ("unit::apply_forward_diff", NULL, NULL);
+        CU_add_test (pSuite, "null_changes_returns_copy",
+                     test_apply_forward_diff_null_changes_returns_copy);
+        CU_add_test (pSuite, "empty_changes_returns_copy",
+                     test_apply_forward_diff_empty_changes_returns_copy);
+        CU_add_test (pSuite, "updates_existing_key",
+                     test_apply_forward_diff_updates_existing_key);
+        CU_add_test (pSuite, "adds_new_key", test_apply_forward_diff_adds_new_key);
+        CU_add_test (pSuite, "null_value_deletes_key",
+                     test_apply_forward_diff_null_value_deletes_key);
+        CU_add_test (pSuite, "nested_object_merges",
+                     test_apply_forward_diff_nested_object_merges);
+
+        pSuite = CU_add_suite ("unit::reconstruct_latest_snapshot", NULL, NULL);
+        CU_add_test (pSuite, "no_diffs_returns_baseline",
+                     test_reconstruct_no_diffs_returns_baseline);
+        CU_add_test (pSuite, "single_diff_applies", test_reconstruct_single_diff_applies);
+        CU_add_test (pSuite, "multiple_diffs_in_order",
+                     test_reconstruct_multiple_diffs_applies_in_order);
+        CU_add_test (pSuite, "diff_with_deletion", test_reconstruct_diff_with_deletion);
+
+        pSuite = CU_add_suite ("unit::append_diff_entry_to_file", NULL, NULL);
+        CU_add_test (pSuite, "appends_to_empty_array", test_append_diff_to_empty_array);
+        CU_add_test (pSuite, "appends_to_nonempty_array",
+                     test_append_diff_to_nonempty_array);
+        CU_add_test (pSuite, "nonexistent_file_fails",
+                     test_append_diff_nonexistent_file_fails);
+
+        pSuite = CU_add_suite ("integration::write_diff", NULL, NULL);
+        CU_add_test (pSuite, "creates_baseline_on_new_file",
+                     test_write_diff_creates_baseline_on_new_file);
+        CU_add_test (pSuite, "appends_empty_diff_when_unchanged",
+                     test_write_diff_appends_empty_diff_when_unchanged);
+        CU_add_test (pSuite, "records_changes", test_write_diff_records_changes);
+        CU_add_test (pSuite, "multiple_polls_accumulates",
+                     test_write_diff_multiple_polls_accumulates_diffs);
+        CU_add_test (pSuite, "reconstructs_from_existing_file",
+                     test_write_diff_reconstruct_from_existing_file);
 
         CU_basic_set_mode (CU_BRM_VERBOSE);
         CU_basic_run_tests ();
@@ -1294,7 +2062,6 @@ main (int argc, char *argv[])
 
         return failures ? -1 : 0;
     }
-
 
     if (!config_dir)
     {


### PR DESCRIPTION
Adding recorder to track changes from given apteryx queries. Polls apteryx at a specified time in seconds and writes results to a specified location in a JSON reverse-diff format. Testing framework has been added, with more tests to come in a later PR. To prevent issues from going unnoticed, the recorder will crash on any bad read. 

Format for a config file specifies:
-  an apteryx query
- a polling frequency in seconds
- a path and filename to write to (**this must be unique to prevent contention**)
- max number of files for logrotate
- max size in MB for logrotate

```
{
    "query": "/test/*",
    "frequency": 5,
    "destination": "./dest/subdir/dump1.json",
    "max_samples": 3,
    "max_size": 1
}
```

Format for the output of JSON diffs specifies:
- timestamp of the last full read
- last full read from the apteryx query
- array of diffs, each containing a timestamp from when they were read and the changes from the next read.

This is a reverse-diff format where the full object is the most recent one. In this example, Memory started out as 5, then moved to 10, then 15. Permanent never changed.

```
{
  "timestamp": 1776915724,
  "current": {
    "Memory": 15
    "Active": 30
    "Permanent": 100
  },
  "diffs": [
    {
      "timestamp": 1776915719,
      "changes": {
        "memory" : 5
      }
    },
    {
      "timestamp": 1776915714,
      "changes": {
        "Memory": 10
        "Active": 25
      }
    }
  ]
}
```